### PR TITLE
Fix hrpsys dependency

### DIFF
--- a/hrpsys_gazebo_tutorials/catkin.cmake
+++ b/hrpsys_gazebo_tutorials/catkin.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_gazebo_tutorials)
 
 #find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge_tutorials collada_tools euscollada)
-find_package(catkin REQUIRED COMPONENTS collada_tools euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials hrpsys)
+find_package(catkin REQUIRED COMPONENTS collada_tools euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
 
 set(PKG_CONFIG_PATH ${hrpsys_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 find_package(PkgConfig)


### PR DESCRIPTION
hrpsys should not be used within find_package macro. it should be found via pkg_check_modules macro
