### PR TITLE
use collada_to_urdf under collada_urdf_jsk_patch instead of collada_tools

### DIFF
--- a/hrpsys_gazebo_tutorials/catkin.cmake
+++ b/hrpsys_gazebo_tutorials/catkin.cmake
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_gazebo_tutorials)
 
-#find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge_tutorials collada_tools euscollada)
-find_package(catkin REQUIRED COMPONENTS collada_tools euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
+find_package(catkin REQUIRED COMPONENTS collada_urdf_jsk_patch euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
 
 set(PKG_CONFIG_PATH ${hrpsys_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 find_package(PkgConfig)
@@ -12,7 +11,7 @@ pkg_check_modules(hrpsys hrpsys-base REQUIRED)
 
 catkin_package(
     DEPENDS
-    CATKIN_DEPENDS collada_tools euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials
+    CATKIN_DEPENDS collada_urdf_jsk_patch euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )
@@ -45,8 +44,8 @@ macro (generate_gazebo_urdf_file _robot_name)
   # ${compile_robots} is a global target used in compile_robot_model.cmake of hrpsys_ros_bridge.
   # this dependency means that run install_robot_common.sh after executing all of ${compile_robots}.
     add_custom_command(OUTPUT ${_out_urdf_file}
-      COMMAND ${PROJECT_SOURCE_DIR}/robot_models/install_robot_common.sh ${_robot_name} ${hrpsys_ros_bridge_tutorials_SOURCE_DIR}/models  ${hrpsys_gazebo_tutorials_SOURCE_DIR}/robot_models/${_robot_name} ${collada_tools_PREFIX}/lib/collada_tools/collada_to_urdf ${PROJECT_SOURCE_DIR}/..
-      DEPENDS ${PROJECT_SOURCE_DIR}/robot_models/install_robot_common.sh ${_out_dir}/hrpsys ${_out_dir}/meshes ${collada_tools_PREFIX}/lib/collada_tools/collada_to_urdf ${compile_robots})
+      COMMAND ${PROJECT_SOURCE_DIR}/robot_models/install_robot_common.sh ${_robot_name} ${hrpsys_ros_bridge_tutorials_SOURCE_DIR}/models  ${hrpsys_gazebo_tutorials_SOURCE_DIR}/robot_models/${_robot_name} ${collada_urdf_jsk_patch_PREFIX}/lib/collada_urdf_jsk_patch/collada_to_urdf ${PROJECT_SOURCE_DIR}/..
+      DEPENDS ${PROJECT_SOURCE_DIR}/robot_models/install_robot_common.sh ${_out_dir}/hrpsys ${_out_dir}/meshes ${collada_urdf_jsk_patch_PREFIX}/lib/collada_urdf_jsk_patch/collada_to_urdf ${compile_robots})
   add_custom_target(${_robot_name}_compile DEPENDS ${_out_urdf_file})
   set(ROBOT ${_robot_name})
   string(TOLOWER ${_robot_name} _sname)

--- a/hrpsys_gazebo_tutorials/manifest.xml
+++ b/hrpsys_gazebo_tutorials/manifest.xml
@@ -14,7 +14,6 @@
   <!--rosdep name="gazebo" /-->
 
   <depend package="hrpsys_gazebo_general" />
-  <depend package="collada_tools" />
   <depend package="collada_urdf_jsk_patch" />
 
   <depend package="hrpsys_ros_bridge_tutorials" />

--- a/hrpsys_gazebo_tutorials/package.xml
+++ b/hrpsys_gazebo_tutorials/package.xml
@@ -10,7 +10,7 @@
   <build_depend>hrpsys_ros_bridge_tutorials</build_depend>
   <build_depend>hrpsys_ros_bridge</build_depend>
   <build_depend>hrpsys_gazebo_general</build_depend>
-  <build_depend>collada_tools</build_depend>
+  <build_depend>collada_urdf_jsk_patch</build_depend>
   <build_depend>openhrp3</build_depend>
   <build_depend>hrpsys</build_depend>
   <build_depend>euscollada</build_depend>
@@ -21,7 +21,6 @@
   <run_depend>hrpsys_ros_bridge</run_depend>
   <run_depend>hrpsys_ros_bridge_tutorials</run_depend>
   <run_depend>hrpsys_gazebo_general</run_depend>
-  <run_depend>collada_tools</run_depend>
+  <run_depend>collada_urdf_jsk_patch</run_depend>
 
 </package>
-

--- a/hrpsys_gazebo_tutorials/robot_models/install_robot_common.sh
+++ b/hrpsys_gazebo_tutorials/robot_models/install_robot_common.sh
@@ -25,7 +25,7 @@ fi
 if [ $# -gt 3 ]; then
     COLLADA_TO_URDF=$4
 else
-    COLLADA_TO_URDF=`rospack find collada_tools`/bin/collada_to_urdf
+    COLLADA_TO_URDF=rosrun\ collada_urdf\ collada_to_urdf
 fi
 
 if [ $# -gt 4 ]; then

--- a/hrpsys_gazebo_tutorials/scripts/eus2urdf_for_gazebo_pyscript.py
+++ b/hrpsys_gazebo_tutorials/scripts/eus2urdf_for_gazebo_pyscript.py
@@ -33,7 +33,7 @@ def eus2urdf_for_gazebo_pyscript (name, collada_path, overwrite=True):
     meshes_path = urdf_dir_path + '/meshes'
     urdf_path = urdf_dir_path + '/' + 'model.urdf'
     os.mkdir(meshes_path)
-    os.system('rosrun collada_tools collada_to_urdf %s -G -A --mesh_output_dir %s --mesh_prefix "model://%s/meshes" -O %s' % (collada_path, meshes_path, name, urdf_path))
+    os.system('rosrun collada_urdf_jsk_patch collada_to_urdf %s -G -A --mesh_output_dir %s --mesh_prefix "model://%s/meshes" -O %s' % (collada_path, meshes_path, name, urdf_path))
     os.system('sed -i -e "s@continuous@revolute@g" %s' % urdf_path)
     os.system('sed -i -e \"s@<robot name=\\"inst_kinsystem\\"@<robot name=\\"%s\\"@g\" %s' % (name, urdf_path))
     os.system('sed -i -e \"1,/  <link /s/  <link /  <gazebo>\\n    <static>false<\/static>\\n  <\/gazebo>\\n  <link /\" %s' % urdf_path)


### PR DESCRIPTION
Use collada_to_urdf under collada_urdf_jsk_patch instead of collada_tools.
When this PR and https://github.com/jsk-ros-pkg/jsk_common/pull/420 are merged, https://github.com/start-jsk/rtmros_gazebo/issues/46 and https://github.com/start-jsk/rtmros_gazebo/issues/48 are resolved.
