### PR TITLE
added load-ros-manifest for sandia_hand_msgs and atlas_msgs

### DIFF
--- a/hrpsys_gazebo_atlas/euslisp/atlas-interface.l
+++ b/hrpsys_gazebo_atlas/euslisp/atlas-interface.l
@@ -12,6 +12,8 @@
 (setq ros::*compile-message* t)
 (ros::roseus-add-msgs "visualization_msgs")
 (ros::roseus-add-msgs "sensor_msgs")
+(ros::load-ros-manifest "sandia_hand_msgs")
+(ros::load-ros-manifest "atlas_msgs")
 ;;(ros::roseus-add-msgs "geometry_msgs")
 (setq ros::*compile-message* nil)
 


### PR DESCRIPTION
This modification was necessary in the environment of @mmurooka and @core-dump .
