### PR TITLE
Generate urdf models for gazebo

### DIFF
--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSK/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSK/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP2JSK.urdf</sdf>
+  <sdf>HRP2JSK_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNT/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNT/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP2JSKNT.urdf</sdf>
+  <sdf>HRP2JSKNT_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNTS/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNTS/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP2JSKNTS.urdf</sdf>
+  <sdf>HRP2JSKNTS_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP3HAND_L/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP3HAND_L/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP3HAND_L.urdf</sdf>
+  <sdf>HRP3HAND_L_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP3HAND_R/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP3HAND_R/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP3HAND_R.urdf</sdf>
+  <sdf>HRP3HAND_R_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP4C/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP4C/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>HRP4C.urdf</sdf>
+  <sdf>HRP4C_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/STARO/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/STARO/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>STARO.urdf</sdf>
+  <sdf>STARO_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/SampleRobot/model.config
+++ b/hrpsys_gazebo_tutorials/robot_models/SampleRobot/model.config
@@ -6,7 +6,7 @@
     <name>Yohei Kakiuchi</name>
     <email>youhei@jsk.t.u-tokyo.ac.jp</email>
   </author>
-  <sdf>SampleRobot.urdf</sdf>
+  <sdf>SampleRobot_for_gazebo.urdf</sdf>
   <description>
     auto generated file ...
   </description>

--- a/hrpsys_gazebo_tutorials/robot_models/install_robot_common.sh
+++ b/hrpsys_gazebo_tutorials/robot_models/install_robot_common.sh
@@ -35,6 +35,7 @@ else
 fi
 
 OUTPUT_FILE=${OUTPUT_DIR}/${ROBOT_NAME}.urdf
+OUTPUT_FILE2=${OUTPUT_DIR}/${ROBOT_NAME}_for_gazebo.urdf
 SED_SCRIPT_FILE=${OUTPUT_DIR}/${ROBOT_NAME}_optional_urdf_setting.sh
 
 if [ ! -e ${INPUT_DIR}/${ROBOT_NAME}.dae ]; then
@@ -42,16 +43,11 @@ if [ ! -e ${INPUT_DIR}/${ROBOT_NAME}.dae ]; then
     exit 0
 fi
 if [ ! -e ${OUTPUT_FILE} ]; then
-##
     mkdir -p ${OUTPUT_DIR}/meshes
     ${COLLADA_TO_URDF} ${INPUT_DIR}/${ROBOT_NAME}.dae -G -A --mesh_output_dir ${OUTPUT_DIR}/meshes --mesh_prefix "package://hrpsys_gazebo_tutorials/robot_models/${ROBOT_NAME}/meshes" --output_file=${OUTPUT_FILE}
-    # if [ ${ROS_DISTRO} == "groovy" ]; then
-    # 	rosrun collada_tools collada_to_urdf ${INPUT_DIR}/${ROBOT_NAME}.dae -G -A --mesh_output_dir ${OUTPUT_DIR}/meshes --mesh_prefix "package://${ROBOT_NAME}/meshes" --output_file=${OUTPUT_FILE}
-    # elif [ ${ROS_DISTRO} == "hydro" ]; then
-    # 	rosrun collada_urdf collada_to_urdf ${INPUT_DIR}/${ROBOT_NAME}.dae -G -A --mesh_output_dir ${OUTPUT_DIR}/meshes --mesh_prefix "package://${ROBOT_NAME}/meshes" --output_file=${OUTPUT_FILE}
-    # fi
-## execute sed
     ${SED_SCRIPT_FILE} ${OUTPUT_FILE} ${ADDITIONAL_ROS_PACKAGE_PATH}
+    cp ${OUTPUT_FILE} ${OUTPUT_FILE2} -f
+    sed -i -e "s@package://hrpsys_gazebo_tutorials/robot_models/@model://@g" ${OUTPUT_FILE2}
 fi
 
 if [ ! -e ${OUTPUT_DIR}/hrpsys ]; then


### PR DESCRIPTION
Generate urdf models for gazebo, in which collada mesh is included by model:// instead of package:// .
Model on gzweb can find only meshes using model://, so this model is necessary.
For robot description, we need to use the urdf models using package://.
