### PR TITLE
use pkg_check_modules instead of find_package for collada_urdf_jsk_patch

### DIFF
--- a/hrpsys_gazebo_tutorials/catkin.cmake
+++ b/hrpsys_gazebo_tutorials/catkin.cmake
@@ -1,17 +1,17 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_gazebo_tutorials)
 
-find_package(catkin REQUIRED COMPONENTS collada_urdf_jsk_patch euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
+find_package(catkin REQUIRED COMPONENTS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
 
 set(PKG_CONFIG_PATH ${hrpsys_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 find_package(PkgConfig)
 pkg_check_modules(openhrp3 openhrp3.1 REQUIRED)
 pkg_check_modules(hrpsys hrpsys-base REQUIRED)
-
+pkg_check_modules(collada_urdf_jsk_patch collada_urdf_jsk_patch)
 
 catkin_package(
     DEPENDS
-    CATKIN_DEPENDS collada_urdf_jsk_patch euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials
+    CATKIN_DEPENDS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )


### PR DESCRIPTION
The reason of https://github.com/start-jsk/rtmros_gazebo/issues/98 is that we use different way for searching package in cmake.

We use `find_package` for collada_urdf_jsk_patch in hrpsys_gazebo_atlas ( https://github.com/start-jsk/rtmros_gazebo/blob/master/hrpsys_gazebo_atlas/catkin.cmake#L28 ),
and use `pkg_check_modules` in hrpsys_gazebo_tutorials ( https://github.com/start-jsk/rtmros_gazebo/blob/master/hrpsys_gazebo_tutorials/catkin.cmake#L4 ).

This PR modifies to use  `pkg_check_modules` for both package.
If you run `catkin_make --only-pkg-with-deps hrpsys_gazebo_tutorials hrpsys_gazebo_atlas` without this PR, you'll get error https://github.com/start-jsk/rtmros_gazebo/issues/98.
