### PR TITLE
fix launching gzserver and gzclient.

### DIFF
--- a/hrpsys_gazebo_tutorials/launch/gazebo_simplebox.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_simplebox.launch
@@ -3,6 +3,6 @@
   <arg name="WORLD" default="SimpleBox.world"/>
 
 
-  <node name="gazebo" pkg="gazebo_ros" type="$(arg gzname)" args="$(find hrpsys_gazebo_tutorials)/worlds/$(arg WORLD)" output="screen" />
+  <node name="gazebo" pkg="hrpsys_gazebo_tutorials" type="$(arg gzname)" args="$(find hrpsys_gazebo_tutorials)/worlds/$(arg WORLD)" output="screen" />
 
 </launch>


### PR DESCRIPTION
We should use gazebo script under hrpsys_gazebo_tutorials in order to switch scripts depending on drcsim installation.
This is same modification with https://github.com/start-jsk/rtmros_gazebo/pull/96.
