### PR TITLE
include atlas_bringup.launch in launch file for hook hand atlas

### DIFF
--- a/hrpsys_gazebo_atlas/launch/atlas_v0_hook_hands.launch
+++ b/hrpsys_gazebo_atlas/launch/atlas_v0_hook_hands.launch
@@ -32,5 +32,5 @@
   <param name="robot_initial_pose/pitch" value="0" type="double"/>
   <param name="robot_initial_pose/yaw"   value="0" type="double"/>
 
-  <!-- <include file="$(find drcsim_gazebo)/launch/atlas_sandia_hands_bringup.launch"/> -->
+  <include file="$(find drcsim_gazebo)/launch/atlas_bringup.launch"/>
 </launch>

--- a/hrpsys_gazebo_atlas/launch/atlas_v3_hook_hands.launch
+++ b/hrpsys_gazebo_atlas/launch/atlas_v3_hook_hands.launch
@@ -31,5 +31,5 @@
   <param name="robot_initial_pose/pitch" value="0" type="double"/>
   <param name="robot_initial_pose/yaw"   value="0" type="double"/>
 
-  <!-- <include file="$(find drcsim_gazebo)/launch/atlas_v3_sandia_hands_bringup.launch"/> -->
+  <include file="$(find drcsim_gazebo)/launch/atlas_v3_bringup.launch"/>
 </launch>


### PR DESCRIPTION
This PR fix #104.
We need to include atlas_bringup.launch or atlas_v3_bringup.launch for atlas simulation.
