### PR TITLE
[hrpsys_gazebo_atlas] Do not compile hrpsys_gazebo_atlas if no drcsim found

### DIFF
--- a/hrpsys_gazebo_atlas/catkin.cmake
+++ b/hrpsys_gazebo_atlas/catkin.cmake
@@ -16,6 +16,13 @@ generate_messages(
 
 catkin_package(CATKIN_DEPENDS hrpsys_gazebo_general atlas_description message_runtime)
 
+# check if atlas_description is available
+find_package(PkgConfig)
+pkg_check_modules(atlas_description atlas_description)
+if (NOT atlas_description_FOUND)
+  message(WARNING "cannot find atlas_description, did you install drcsim?")
+  return()
+endif(NOT atlas_description_FOUND)
 
 if(EXISTS ${hrpsys_ros_bridge_SOURCE_DIR})
   set(hrpsys_ros_bridge_PACKAGE_PATH ${hrpsys_ros_bridge_SOURCE_DIR})


### PR DESCRIPTION
Do not compile hrpsys_gazebo_atlas if no drcsim found. Once we use `catkin build`, we need to compile all the packages, and drcsim dependency is a little bit tricky.

I hope [this](https://bitbucket.org/osrf/drcsim/issue/451/release-deb-of-atlas_description) solve this issue.