### PR TITLE
[hrpsys_gaezbo_general] add LaserScanIntensityFilter node

### DIFF
--- a/hrpsys_gazebo_general/catkin.cmake
+++ b/hrpsys_gazebo_general/catkin.cmake
@@ -2,7 +2,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_gazebo_general)
 
-find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge hrpsys_gazebo_msgs)
+find_package(catkin REQUIRED COMPONENTS
+  hrpsys_ros_bridge
+  hrpsys_gazebo_msgs
+  sensor_msgs
+  roscpp)
 
 find_package(PkgConfig)
 pkg_check_modules(openrtm_aist openrtm-aist REQUIRED)
@@ -54,6 +58,10 @@ include_directories( ${GAZEBO_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${openrtm_ais
 link_directories( ${GAZEBO_LIBRARY_DIRS} ${openhrp3_LIBRARY_DIRS})
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/plugins)
+
+add_executable(laser_scan_intensity_filter src/LaserScanIntensityFilter.cpp)
+target_link_libraries(laser_scan_intensity_filter ${catkin_LIBRARIES})
+install(TARGETS laser_scan_intensity_filter RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 add_library(IOBPlugin src/IOBPlugin.cpp)
 add_dependencies(IOBPlugin hrpsys_gazebo_msgs_gencpp)

--- a/hrpsys_gazebo_general/src/LaserScanIntensityFilter.cpp
+++ b/hrpsys_gazebo_general/src/LaserScanIntensityFilter.cpp
@@ -1,0 +1,88 @@
+/*
+ * LaserScanIntensityFilter.cpp
+ * Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <vector>
+#include <algorithm>
+#include <iterator>
+#include <boost/shared_ptr.hpp>
+
+#include <ros/ros.h>
+#include <sensor_msgs/LaserScan.h>
+
+namespace hrpsys_gazebo_general
+{
+
+class LaserScanIntensityFilter
+{
+public:
+  ros::NodeHandle nh_;
+
+  ros::Publisher  pub_;
+  ros::Subscriber sub_;
+
+  int subscriberCount_;
+  sensor_msgs::LaserScanPtr pub_msg_;
+
+  LaserScanIntensityFilter() {
+    subscriberCount_ = 0;
+    pub_msg_ = boost::shared_ptr<sensor_msgs::LaserScan>(new sensor_msgs::LaserScan());
+    ros::SubscriberStatusCallback connectCallback = boost::bind(&LaserScanIntensityFilter::connectCallback, this, _1);
+    ros::SubscriberStatusCallback disconnectCallback = boost::bind(&LaserScanIntensityFilter::disconnectCallback, this, _1);
+    pub_ = nh_.advertise<sensor_msgs::LaserScan>("output", 1, connectCallback, disconnectCallback);
+  };
+
+  ~LaserScanIntensityFilter() {};
+
+  void messageCallback(const sensor_msgs::LaserScanConstPtr &msg) {
+    pub_msg_->header = msg->header;
+    pub_msg_->angle_min = msg->angle_min;
+    pub_msg_->angle_max = msg->angle_max;
+    pub_msg_->angle_increment = msg->angle_increment;
+    pub_msg_->time_increment = msg->time_increment;
+    pub_msg_->scan_time = msg->scan_time;
+    pub_msg_->range_min = msg->range_min;
+    pub_msg_->range_max = msg->range_max;
+
+    pub_msg_->ranges.clear();
+    pub_msg_->ranges.reserve(msg->ranges.size());
+    std::copy(msg->ranges.begin(), msg->ranges.end(), std::back_inserter(pub_msg_->ranges));
+
+    pub_.publish(*pub_msg_);
+  }
+
+  void subscribe() {
+    ROS_INFO("subscribe laserscan topic");
+    sub_ = nh_.subscribe("input", 1, &LaserScanIntensityFilter::messageCallback, this);
+  }
+
+  void unsubscribe() {
+    ROS_INFO("unsubscribe laserscan topic");
+    sub_.shutdown();
+  }
+
+  void connectCallback(const ros::SingleSubscriberPublisher&) {
+    if (subscriberCount_++ == 0) {
+      subscribe();
+    }
+  }
+
+  void disconnectCallback(const ros::SingleSubscriberPublisher&) {
+    subscriberCount_--;
+    if (subscriberCount_ == 0) {
+      unsubscribe();
+    }
+  }
+
+};
+}
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "laser_scan_intensity_filter");
+  hrpsys_gazebo_general::LaserScanIntensityFilter f;
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
`LaserScanIntensityFilter` node removes `intensities` slot from `sensor_msgs/LaserScan`.
gazebo on hydro version publishes wrong intensities, so this node may not be necessary above indigo.