### PR TITLE
IOBPlugin で力センサをフィルタする

### DIFF
--- a/hrpsys_gazebo_general/src/IOBPlugin.h
+++ b/hrpsys_gazebo_general/src/IOBPlugin.h
@@ -193,5 +193,9 @@ namespace gazebo
       return 0.0;
     }
 
+    int force_sensor_average_window_size;
+    int force_sensor_average_cnt;
+
+    std::map<std::string, boost::shared_ptr<std::vector<boost::shared_ptr<geometry_msgs::WrenchStamped> > > > forceValQueueMap;
   };
 }


### PR DESCRIPTION
xacro で "force_sensor_average_window_size" を変えると、力センサをシミュレーション時間で平均する時間幅を変更できます。 default は 5 です。

簡単な動作確認として、

・ rqt_plot でフィルタありなしの力センサをプロットして振動が収まっていることを確認しました。
・ go-velocity 0 0 10 で3周ぐらいしても転ばないことを確認しました。

see #119 