### PR TITLE
[hrosys_gazebo_general/iob.cpp]check number_of_joints

### DIFF
--- a/hrpsys_gazebo_general/iob/iob.cpp
+++ b/hrpsys_gazebo_general/iob/iob.cpp
@@ -368,17 +368,19 @@ int write_command_angles(const double *angles)
     send_com.header.stamp = ros::Time::now();
 
     for (int i=0; i<NUM_OF_REAL_JOINT; i++) {
+      if (JOINT_ID_REAL2MODEL(i) < number_of_joints()){
 #if USE_SERVO_ON
-      if (servo[JOINT_ID_REAL2MODEL(i)] > 0) {
-        send_com.position[i] = command[JOINT_ID_REAL2MODEL(i)];
-        send_com.velocity[i] = (command[JOINT_ID_REAL2MODEL(i)] - prev_command[JOINT_ID_REAL2MODEL(i)]) / (overwrite_g_period_ns * 1e-9);
-      } else {
-        servo_on = false;
-      }
+	if (servo[JOINT_ID_REAL2MODEL(i)] > 0) {
+	  send_com.position[i] = command[JOINT_ID_REAL2MODEL(i)];
+	  send_com.velocity[i] = (command[JOINT_ID_REAL2MODEL(i)] - prev_command[JOINT_ID_REAL2MODEL(i)]) / (overwrite_g_period_ns * 1e-9);
+	} else {
+	  servo_on = false;
+	}
 #else
-      send_com.position[i] = command[JOINT_ID_REAL2MODEL(i)];
-      send_com.velocity[i] = (command[JOINT_ID_REAL2MODEL(i)] - prev_command[JOINT_ID_REAL2MODEL(i)]) / (overwrite_g_period_ns * 1e-9);
+	send_com.position[i] = command[JOINT_ID_REAL2MODEL(i)];
+	send_com.velocity[i] = (command[JOINT_ID_REAL2MODEL(i)] - prev_command[JOINT_ID_REAL2MODEL(i)]) / (overwrite_g_period_ns * 1e-9);
 #endif
+      }
     }
 
     if (iob_synchronized) {


### PR DESCRIPTION
hrpsys_gazebo_general/iob/iob.cppの
https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/iob/iob.cpp#L370-L382
の，```command[JOINT_ID_REAL2MODEL(i)]```,```prev_command[JOINT_ID_REAL2MODEL(i)]```が，配列の範囲外へアクセスしています．

アクセス前に配列のサイズを確認するようにしました．


以下，現状の説明です．
***発生条件***
hrpsysがロードするモデルファイルとgazeboがロードするモデルファイルが異なり，gazeboのIOBPluginが扱う関節の中にhrpsysが扱わない関節がある場合に，
https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/iob/iob.cpp#L742
で読み込む```joint_id_list```に書かれた数字の中に，hrpsysの関節数以上の数字が書かれている場合．
(例えばhrp2jskntsは，HPR3Handが付いているため，hrpsysで扱う関節は34個ですが，IOBPluginが扱う関節は46個です)

***問題点***
配列```command```,```prev_command```は
https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/iob/iob.cpp#L158-L159
https://github.com/fkanehiro/hrpsys-base/blob/fd3bf75a1dc9d0e14898ff11a7c2f35b525f5b59/rtc/RobotHardware/robot.cpp#L78
でサイズがhrp::Body::numJoints()，即ちhrpsysがロードするモデルファイルの関節数に等しくなるように定められています．

一方，'''JOINT_ID_REAL2MODEL(i)'''は，gazeboのIOBPluginに合わせて人が.yamlファイルの```joint_id_list```に書いた数字がそのまま入っているため，```command```,```prev_command```のサイズ以上の数字が書かれている可能性があります．

***症状***
プログラムが止まることはありませんが，配列の範囲外にアクセスしてしまう関節はgazeboに送られる```joint_command```トピックの```position```,```velocity```の指令値に4.00135071e-314，2.660006257743614e+250などの値が入ってしまいます．