### PR TITLE
[hrpsys_gazebo_general]IOBplugin fix frame conversion of force-sensor

### DIFF
--- a/hrpsys_gazebo_general/src/IOBPlugin.cpp
+++ b/hrpsys_gazebo_general/src/IOBPlugin.cpp
@@ -837,15 +837,16 @@ void IOBPlugin::GetRobotStates(const common::Time &_curTime){
         this->robotState.sensors[i].name = this->forceSensorNames[i];
         this->robotState.sensors[i].frame_id = it->second.frame_id;
         if (!!it->second.pose) {
-          // convert force
-          math::Vector3 force_trans = it->second.pose->rot * wrench.body2Force;
-          math::Vector3 torque_trans = it->second.pose->rot * wrench.body2Torque;
+          // convert moment (around joint -> around sensor)
+	  math::Vector3 sen_moment = wrench.body2Torque - it->second.pose->pos.Cross(wrench.body2Force);
+	  // convert forcemoment frame (childlink frame -> sensor frame)
+          math::Vector3 force_trans = it->second.pose->rot.RotateVectorReverse(wrench.body2Force);
+          math::Vector3 torque_trans = it->second.pose->rot.RotateVectorReverse(sen_moment);
           // rotate force
           forceVal->wrench.force.x = force_trans.x;
           forceVal->wrench.force.y = force_trans.y;
           forceVal->wrench.force.z = force_trans.z;
           // rotate torque + additional torque
-          torque_trans += it->second.pose->pos.Cross(force_trans);
           forceVal->wrench.torque.x = torque_trans.x;
           forceVal->wrench.torque.y = torque_trans.y;
           forceVal->wrench.torque.z = torque_trans.z;


### PR DESCRIPTION
IOBPlugin.cppでgazeboからForceSensorの値を取得する際の変換が正しくないのではないかというpull requestです。

gazeboからForceSensorの値を取得するために、.yamlファイルでセンサの位置を指定します。
指定する各パラメータは、hrpsys_gazebo_tutorialsにあるロボットでは、以下のような使われ方をしています。
例 ：
https://github.com/start-jsk/rtmros_tutorials/blob/a546adde4cf517082c47a68bbf58eba2dbd51fae/hrpsys_gazebo_tutorials/config/HRP2JSKNTS.yaml#L117-L120
```
force_torque_sensors/joint_name  (センサが付いているLinkのparent joint)
force_torque_sensors/translation (上記jointからセンサへのベクトルをセンサが付いているLinkの座標系で表したもの)
force_torque_sensors/rotation(センサが付いているLink座標系から見たセンサの傾き)
```

一方、hrpsys_gazebo_general/IOBPluginでは、受けとった各パラメータを以下のように異なる解釈をして力やモーメントを変換しています。
```
force_torque_sensors/joint_name  (センサが付いているLinkのparent joint)
force_torque_sensors/translation (センサから上記jointへのベクトルをセンサ座標系で表したもの)
force_torque_sensors/rotation (センサ座標系から見たセンサが付いているLinkの傾き)
```

IOBPlugin側をhrpsys_gazebo_tutorialsにあるロボットでの使われ方に合わせました。