### PR TITLE
[on #242] add Craneplugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,38 @@ This is yaml file for configuring gazebo setting.
       imu_sensors_config:
         imu_sensor0: {ros_name: 'ros_imu_sensor', link_name: 'LINK_NAME0', frame_id: 'LINK_NAME0'}
 
+### Custom Plugins
+
+### CranePlugin
+
+This plugin provides fake "Crane" in gazebo environment.
+
+```
+<gazebo>
+  <plugin filename="libCranePlugin.so" name="crane_plugin">
+    <linkname>CHEST_LINK1</linkname>  <!-- The name of the link where the crane is attached -->
+    <liftheight>1.2</liftheight>  <!-- Crane hanging height [m] -->
+    <lowerheight>0.5</lowerheight>  <!-- Crane will be disabled below this height [m] -->
+    <liftvelocity>0.1</liftvelocity>  <!-- [m/s] -->
+    <lowervelocity>0.03</lowervelocity>  <!-- [m/s] -->
+    <pgain>2500</pgain>  <!-- P gain for Z-axis error -->
+    <dgain>500</dgain>  <!-- D gain for Z-axis error -->
+    <damp>10000</damp>  <!-- Damping factor for other axes and rotation -->
+  </plugin>
+</gazebo>
+```
+
+#### Subscribed topics
+
+- `[objname]/CranePlugin/LowerCommand` (`std_msgs::Empty`)
+Lower the crane to the ground.
+
+- `[objname]/CranePlugin/LiftCommand` (`std_msgs::Empty`)
+Lift the crane to the lift height.
+
+- `[objname]/CranePlugin/PoseCommand` (`geometry_msgs::Pose`)
+Place the robot to the pose.
+
 [gazebo]:http://gazebosim.org
 [rtmros_common]:https://github.com/start-jsk/rtmros_common
 [hrpsys_gazebo_general]:https://github.com/start-jsk/rtmros_gazebo/tree/master/hrpsys_gazebo_general

--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ This is yaml file for configuring gazebo setting.
       imu_sensors_config:
         imu_sensor0: {ros_name: 'ros_imu_sensor', link_name: 'LINK_NAME0', frame_id: 'LINK_NAME0'}
 
-### Custom Plugins
+#### Custom Plugins
 
-### CranePlugin
+#### CranePlugin
 
 This plugin provides fake "Crane" in gazebo environment.
 
+To use this plugin, add the following lines to your URDF.
 ```
 <gazebo>
   <plugin filename="libCranePlugin.so" name="crane_plugin">
@@ -114,15 +115,18 @@ This plugin provides fake "Crane" in gazebo environment.
 </gazebo>
 ```
 
-#### Subscribed topics
+##### Subscribed topics
 
 - `[objname]/CranePlugin/LowerCommand` (`std_msgs::Empty`)
+
 Lower the crane to the ground.
 
 - `[objname]/CranePlugin/LiftCommand` (`std_msgs::Empty`)
+
 Lift the crane to the lift height.
 
 - `[objname]/CranePlugin/PoseCommand` (`geometry_msgs::Pose`)
+
 Place the robot to the pose.
 
 [gazebo]:http://gazebosim.org

--- a/hrpsys_gazebo_general/CMakeLists.txt
+++ b/hrpsys_gazebo_general/CMakeLists.txt
@@ -81,6 +81,9 @@ install(TARGETS ThermoPlugin LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATIO
 add_library(LIPPlugin src/LIPPlugin.cpp)
 add_dependencies(LIPPlugin hrpsys_gazebo_msgs_gencpp)
 install(TARGETS LIPPlugin LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+add_library(CranePlugin src/CranePlugin.cpp)
+add_dependencies(CranePlugin hrpsys_gazebo_msgs_gencpp)
+install(TARGETS CranePlugin LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 ## Convert robot models
 include(${PROJECT_SOURCE_DIR}/cmake/compile_robot_model_for_gazebo.cmake)

--- a/hrpsys_gazebo_general/src/CranePlugin.cpp
+++ b/hrpsys_gazebo_general/src/CranePlugin.cpp
@@ -32,7 +32,7 @@ namespace gazebo
       this->world = this->model->GetWorld();
 
       // read option args in sdf tags
-      this->obj_name = "";
+      this->obj_name = this->model->GetName();
       if (_sdf->HasElement("objname")) {
         this->obj_name = _sdf->Get<std::string>("objname");
       }
@@ -248,7 +248,7 @@ namespace gazebo
 #else
 	if (!math::equal(dt,0.0)) derror=(error-pre_error)/dt;
 #endif
-	double F_z = pgain * error + dgain * derror;
+	double F_z = this->pgain * error + this->dgain * derror;
 	if (F_z>0.0){
 #if GAZEBO_MAJOR_VERSION >= 9
 	  ignition::math::Vector3d lin_f = - lin * this->damp;
@@ -269,8 +269,8 @@ namespace gazebo
 	this->model->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
 	this->model->SetAngularVel(ignition::math::Vector3d(0, 0, 0));
 #else
-	this->model->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
-	this->model->SetAngularVel(ignition::math::Vector3d(0, 0, 0));
+	this->model->SetLinearVel(math::Vector3(0, 0, 0));
+	this->model->SetAngularVel(math::Vector3(0, 0, 0));
 #endif
 	this->model->SetWorldPose(this->pose);
 	this->set_pose_flag = false;

--- a/hrpsys_gazebo_general/src/CranePlugin.cpp
+++ b/hrpsys_gazebo_general/src/CranePlugin.cpp
@@ -1,0 +1,289 @@
+#include <iostream>
+#include <stdio.h>
+
+#include <boost/bind.hpp>
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/common/common.hh>
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+#include <ros/subscribe_options.h>
+
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/Wrench.h>
+#include <std_msgs/Empty.h>
+
+
+namespace gazebo
+{
+  class Crane : public ModelPlugin
+  {
+
+  public:
+    // Initialize
+    void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
+    {
+      // Store the pointer to the model
+      this->model = _parent;
+      this->world = this->model->GetWorld();
+
+      // read option args in sdf tags
+      this->obj_name = "";
+      if (_sdf->HasElement("objname")) {
+        this->obj_name = _sdf->Get<std::string>("objname");
+      }
+      this->link_name = "root";
+      if (_sdf->HasElement("linkname")) {
+        this->link_name = _sdf->Get<std::string>("linkname");
+      }
+      this->topic_name = "CranePlugin";
+      if (_sdf->HasElement("topicname")) {
+        this->topic_name = _sdf->Get<std::string>("topicname");
+      }
+
+      // find root link
+      this->link = this->model->GetLink(this->link_name);
+      if(!this->link) {
+        gzerr << "[CranePlugin] Root link are not found. (link_name is "<< this->link_name << ")" << std::endl;
+        return;
+      }
+
+      // find pull up height
+      this->lift_height = 2.0;
+      if (_sdf->HasElement("liftheight")) {
+	this->lift_height = _sdf->Get<double>("liftheight");
+      }
+
+      //find lift velocity
+      this->lift_velocity = 1.0;
+      if (_sdf->HasElement("liftvelocity")) {
+        this->lift_velocity = _sdf->Get<double>("liftvelocity");
+      }
+      
+      //find lower velocity
+      this->lower_velocity = 1.0;
+      if (_sdf->HasElement("lowervelocity")) {
+        this->lower_velocity = _sdf->Get<double>("lowervelocity");
+      }
+
+      //find lower height
+      this->lower_height = 0.0;
+      if (_sdf->HasElement("lowerheight")) {
+        this->lower_height = _sdf->Get<double>("lowerheight");
+      }
+
+      //find pgain
+      this->pgain = 10000;
+      if (_sdf->HasElement("pgain")) {
+        this->pgain = _sdf->Get<double>("pgain");
+      }
+      //find dgain
+      this->dgain = 10;
+      if (_sdf->HasElement("dgain")) {
+        this->pgain = _sdf->Get<double>("dgain");
+      }
+
+      //find damp
+      this->damp = 1;
+      if (_sdf->HasElement("damp")) {
+        this->damp = _sdf->Get<double>("damp");
+      }
+
+      // initialize
+      bool liftstart = true;
+      if (_sdf->HasElement("liftstart")) {
+	liftstart = _sdf->Get<bool>("liftstart");
+      }
+      if (liftstart) {
+	std_msgs::Empty::ConstPtr msg;
+	LiftCommand(msg);
+      } else {
+	std_msgs::Empty::ConstPtr msg;
+	LowerCommand(msg);
+      }
+      this->set_pose_flag = false;
+
+      // Make sure the ROS node for Gazebo has already been initialized
+      if (!ros::isInitialized()) {
+        gzerr << "[CranePlugin] A ROS node for Gazebo has not been initialized, unable to load plugin. "
+              << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)";
+        return;
+      }
+      // ros node
+      this->rosNode = new ros::NodeHandle("");
+      // ros callback queue for processing subscription
+      this->deferredLoadThread = boost::thread(boost::bind(&Crane::DeferredLoad, this));
+    }
+
+    void DeferredLoad() {
+      // ros topic subscribtions
+      ros::SubscribeOptions LiftCommandSo =
+        ros::SubscribeOptions::create<std_msgs::Empty>("/" + this->obj_name + "/" + this->topic_name + "/LiftCommand", 100,
+                                                    boost::bind(&Crane::LiftCommand, this, _1),
+                                                    ros::VoidPtr(), &this->rosQueue);
+      ros::SubscribeOptions LowerCommandSo =
+        ros::SubscribeOptions::create<std_msgs::Empty>("/" + this->obj_name + "/" + this->topic_name + "/LowerCommand", 100,
+                                              boost::bind(&Crane::LowerCommand, this, _1),
+                                              ros::VoidPtr(), &this->rosQueue);
+      ros::SubscribeOptions PoseCommandSo =
+        ros::SubscribeOptions::create<geometry_msgs::Pose>("/" + this->obj_name + "/" + this->topic_name + "/PoseCommand", 100,
+                                              boost::bind(&Crane::SetPoseCommand, this, _1),
+                                              ros::VoidPtr(), &this->rosQueue);
+      // Enable TCP_NODELAY because TCP causes bursty communication with high jitter,
+      LiftCommandSo.transport_hints = ros::TransportHints().reliable().tcpNoDelay(true);
+      this->subLiftCommand = this->rosNode->subscribe(LiftCommandSo);
+      LowerCommandSo.transport_hints = ros::TransportHints().reliable().tcpNoDelay(true);
+      this->subLowerCommand = this->rosNode->subscribe(LowerCommandSo);
+      PoseCommandSo.transport_hints = ros::TransportHints().reliable().tcpNoDelay(true);
+      this->subPoseCommand = this->rosNode->subscribe(PoseCommandSo);
+
+      // ros callback queue for processing subscription
+      this->callbackQueeuThread = boost::thread(boost::bind(&Crane::RosQueueThread, this));
+
+      // Listen to the update event.
+      this->updateConnection = event::Events::ConnectWorldUpdateEnd(boost::bind(&Crane::OnUpdate, this));
+
+      ROS_INFO("CranePlugin was loaded !");
+    }
+
+    void LiftCommand(const std_msgs::Empty::ConstPtr &_msg)
+    {
+      this->pull_up_flag = true;
+      this->pull_down_flag = false;
+      this->target_height = this->link->GetWorldPose().pos.z;
+      this->lift_fin = false;
+      // initialize update time
+      this->lastUpdateTime = this->world->GetSimTime();
+      this->count = 0;
+      gzmsg << "[CranePlugin]subscribed LiftCommand." << std::endl;      
+    }
+
+    void LowerCommand(const std_msgs::Empty::ConstPtr &_msg)
+    {
+      if(this->pull_up_flag){
+	this->pull_up_flag = false;
+	this->pull_down_flag = true;
+	// initialize update time
+	this->lastUpdateTime = this->world->GetSimTime();
+      }
+      gzdbg << "[CranePlugin]subscribed LowerCommand." << std::endl;
+    }
+
+
+    void SetPoseCommand(const geometry_msgs::Pose::ConstPtr &_msg)
+    {
+      this->pose.Set(math::Vector3(_msg->position.x, _msg->position.y, _msg->position.z),
+                     math::Quaternion(_msg->orientation.w, _msg->orientation.x, _msg->orientation.y, _msg->orientation.z));
+      this->set_pose_flag = true;
+      this->pull_up_flag = false;
+      this->pull_down_flag = false;
+      gzdbg << "[CranePlugin]subscribed SetPoseCommand. ( position: " << this->pose.pos << "  orientation: " << this->pose.rot << " )" << std::endl;
+    }
+
+    // Called by the world update start event
+    void OnUpdate()
+    {
+      if (this->pull_up_flag||this->pull_down_flag) {
+	common::Time curTime = this->world->GetSimTime();
+	if (this->pull_up_flag){
+	  if(this->target_height<this->lift_height){
+	    this->target_height+=lift_velocity * (curTime - this->lastUpdateTime).Double();
+	  }else{
+	    this->target_height=this->lift_height;
+	    count++;
+	    if(count%100==0){
+	      math::Vector3 lin=this->model->GetWorldLinearVel();
+	      math::Vector3 ang=this->model->GetWorldAngularVel();
+	      lin *= 0.7;
+	      ang *= 0.7;
+	      this->model->SetWorldTwist(lin,ang);
+	    }
+	    // if(!this->lift_fin){
+	    //   this->lift_fin=true;
+	    //   math::Quaternion tmp=this->link->GetWorldPose().rot;
+	    //   math::Vector3 vec=this->link->GetWorldPose().pos;
+	    //   this->model->SetLinkWorldPose(math::Pose(vec,math::Quaternion(0.0,0.0,tmp.GetYaw())),this->link);
+	    //   this->model->SetWorldTwist(math::Vector3(),math::Vector3());
+	    // }
+	  }
+	}
+	if (this->pull_down_flag){
+	  if(this->target_height<this->lower_height){
+	    this->pull_down_flag=false;
+	    return;
+	  }
+	  this->target_height-=lower_velocity * (curTime - this->lastUpdateTime).Double();
+	}
+	double error  = this->target_height - this->link->GetWorldPose().pos.z;
+	double derror = 0.0;
+	if (!math::equal((curTime - this->lastUpdateTime).Double(),0.0)){
+	  derror=(error-pre_error)/(curTime - this->lastUpdateTime).Double();
+	}
+	double F_z = pgain * error + dgain * derror;
+	if (F_z>0.0){
+	  math::Vector3 lin=this->model->GetWorldLinearVel();
+	  math::Vector3 ang=this->model->GetWorldAngularVel();
+	  lin *= -this->damp;
+	  ang *= -this->damp;
+	  lin.z=F_z; 
+	  this->link->AddForce(lin);
+	  this->link->AddTorque(ang);
+	}
+	this->lastUpdateTime = curTime;
+      }else if (this->set_pose_flag) {
+	this->model->SetLinearVel(math::Vector3(0, 0, 0));
+	this->model->SetAngularVel(math::Vector3(0, 0, 0));
+	this->model->SetWorldPose(this->pose);
+	this->set_pose_flag = false;
+      }
+    }
+    
+    // Ros loop thread function
+    void RosQueueThread() {
+      static const double timeout = 0.01;
+
+      while (this->rosNode->ok()) {
+        this->rosQueue.callAvailable(ros::WallDuration(timeout));
+      }
+    }
+
+  private:
+    physics::WorldPtr world;
+    physics::ModelPtr model;
+    std::string obj_name;
+    std::string link_name;
+    std::string topic_name;
+    double lift_height;
+    double lower_height;
+    double target_height;
+    double lift_velocity;
+    double lower_velocity;
+    double pgain;
+    double dgain;
+    double pre_error;
+    bool lift_fin;
+    physics::LinkPtr link;
+    event::ConnectionPtr updateConnection;
+    bool pull_up_flag;
+    bool pull_down_flag;
+    bool damp;
+    common::Time lastUpdateTime;
+    int count;
+    math::Pose pose;
+    bool set_pose_flag;
+
+    ros::NodeHandle* rosNode;
+    ros::CallbackQueue rosQueue;
+    ros::Subscriber subLiftCommand;
+    ros::Subscriber subLowerCommand;
+    ros::Subscriber subPoseCommand;
+    boost::thread callbackQueeuThread;
+    boost::thread deferredLoadThread;
+  };
+
+  GZ_REGISTER_MODEL_PLUGIN(Crane)
+}


### PR DESCRIPTION
gazeboでクレーンを使用するためのプラグインです。
gazeboでロボットを地面に置きたい時に、従来は地面より少し高い位置を指定してロボットをワープさせて落とすという手法をとっていましたが、
このプラグインを使うことで①落とすことなく、②正確なZ方向位置を指定することなく、ロボットを地面に置くことが可能になります。

URDFの<robot>以下に以下のようなタグを加えることで使用できます。
```
 <gazebo>                                                                      
    <plugin filename="libCranePlugin.so" name="crane_plugin">                   
      <objname>HRP2JSKNTS</objname>                                             
      <linkname>CHEST_LINK1</linkname>                                          
      <liftheight>1.2</liftheight>                                              
      <lowerheight>0.5</lowerheight>                                            
      <liftvelocity>0.1</liftvelocity>                                          
      <lowervelocity>0.03</lowervelocity>                                       
      <pgain>2500</pgain>                                                       
      <dgain>500</dgain>                                                        
      <damp>10000</damp>                                                        
    </plugin>                                                                   
  </gazebo>   
```

```linkname```のリンクに対し、```liftheight```の高さになるように```pgain``` ```dgain```の値を用いてPD制御で外力を加えます。
紐で吊るされた状態を想定しているため、鉛直上向きにのみ外力を加え、下向きには外力を加えません。

```objname/name/LowerCommand```にstd_msgs/Emptyトピックを送ると、目標高さが```lowerheight```まで```lowervelocity```の速さで徐々に下がり、目標高さが```lowerheight```に到達するとこのプラグインが無効になります。

```objname/name/LiftCommand```にstd_msgs/Emptyトピックを送ると、このプラグインが再度有効になり、目標高さが```liftheight```まで```liftvelocity```の速さで徐々に上がります。
