### PR TITLE
[on #242] add options to gazebo_robot_no_controllers.launch

### DIFF
--- a/hrpsys_gazebo_general/launch/gazebo_robot_no_controllers.launch
+++ b/hrpsys_gazebo_general/launch/gazebo_robot_no_controllers.launch
@@ -54,9 +54,14 @@
   </group>
 
   <!-- Robot Description -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg ROBOT_MODEL)'" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <arg name="USE_CALIBRATED_URDF" default="false"/>
+  <arg name="CALIB_FILE_COMMAND" default=""/>
+  <param name="robot_description" command="$(find xacro)/xacro '$(arg ROBOT_MODEL)'" unless="$(arg USE_CALIBRATED_URDF)"/>
+  <param name="robot_description" command="$(arg CALIB_FILE_COMMAND)" if="$(arg USE_CALIBRATED_URDF)"/>
 
+  <arg name="use_robot_state_publisher" default="true"/>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" if="$(arg use_robot_state_publisher)"/>
+  
   <!-- Spawn Robot Model -->
   <node if="$(arg SPAWN_MODEL)"
         name="spawn_robot_model" pkg="gazebo_ros" type="spawn_model"


### PR DESCRIPTION
This PR adds three arguments to gazebo_robot_no_controllers.launch for HRP2 simulation.
This PR does not affect default behavior.
