### PR TITLE
Enable samplerobot sample in kinetic

### DIFF
--- a/hrpsys_gazebo_general/config/SampleRobot.conf
+++ b/hrpsys_gazebo_general/config/SampleRobot.conf
@@ -1,6 +1,0 @@
-model: file://$(PROJECT_DIR)/..//model/sample1.wrl
-dt: 0.005
-
-abc_leg_offset: 0,0.09,0
-abc_stride_parameter: 0.15,0.05,10
-end_effectors: rarm,RARM_WRIST_P,CHEST,0.0,-5.684342e-17,-0.12,9.813078e-18,1.0,0.0,1.5708, larm,LARM_WRIST_P,CHEST,0.0,5.684342e-17,-0.12,-9.813078e-18,1.0,0.0,1.5708, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0,

--- a/hrpsys_gazebo_general/config/SampleRobot.yaml
+++ b/hrpsys_gazebo_general/config/SampleRobot.yaml
@@ -1,6 +1,7 @@
 hrpsys_gazebo_configuration:
 ## velocity feedback for joint control, use parameter gains/joint_name/p_v
   use_velocity_feedback: false
+  iob_rate: 500
 ## synchronized hrpsys and gazebo
 # use_synchronized_command: false
 # name of robot (using for namespace)

--- a/hrpsys_gazebo_general/config/SampleRobot.yaml
+++ b/hrpsys_gazebo_general/config/SampleRobot.yaml
@@ -117,6 +117,7 @@ hrpsys_gazebo_configuration:
 ## IMU sensor settings
 ## configuration of IMU sensor
 ## key of imu_sensors_config should be a member of imu_sensors
+## pose of IMU sensor should be written in URDF
   imu_sensors:
     - imu_sensor0
   imu_sensors_config:

--- a/hrpsys_gazebo_general/config/SampleRobot.yaml
+++ b/hrpsys_gazebo_general/config/SampleRobot.yaml
@@ -1,6 +1,6 @@
 hrpsys_gazebo_configuration:
 ## velocity feedback for joint control, use parameter gains/joint_name/p_v
-  use_velocity_feedback: true
+  use_velocity_feedback: false
 ## synchronized hrpsys and gazebo
 # use_synchronized_command: false
 # name of robot (using for namespace)
@@ -70,18 +70,18 @@ hrpsys_gazebo_configuration:
 # 28  - CHEST
 ## joint gain settings
   gains:
-    LLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_R:      {p: 6000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_P:      {p: 12000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_Y:      {p:  2000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_KNEE:       {p: 18000.0, d:  6.0, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_P:    {p: 9000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_R:    {p:  3000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_R:      {p: 6000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_P:      {p: 12000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_Y:      {p:  2000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_KNEE:       {p: 18000.0, d:  6.0, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_P:    {p: 9000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_R:    {p:  3000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
     WAIST_P:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
     WAIST_R:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
     CHEST:           {p: 6000.0, d:   2.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}

--- a/hrpsys_gazebo_general/config/SampleRobot.yaml
+++ b/hrpsys_gazebo_general/config/SampleRobot.yaml
@@ -71,35 +71,35 @@ hrpsys_gazebo_configuration:
 # 28  - CHEST
 ## joint gain settings
   gains:
-    LLEG_HIP_R:      {p: 6000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_P:      {p: 12000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_Y:      {p:  2000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_KNEE:       {p: 18000.0, d:  6.0, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_P:    {p: 9000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_R:    {p:  3000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_R:      {p: 6000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_P:      {p: 12000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_Y:      {p:  2000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_KNEE:       {p: 18000.0, d:  6.0, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_P:    {p: 9000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_R:    {p:  3000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
-    WAIST_P:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    WAIST_R:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    CHEST:           {p: 6000.0, d:   2.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    LARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
-    LARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    LARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    RARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
-    RARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    RARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LLEG_HIP_R:      {p: 6000.0, d:  0.1, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_P:      {p: 6000.0, d:  0.15, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_Y:      {p:  2000.0, d:  0.1, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_KNEE:       {p: 9000.0, d:  0.15, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_P:    {p: 4500.0, d:  0.075, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_R:    {p:  3000.0, d:  0.05, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_R:      {p: 6000.0, d:  0.1, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_P:      {p: 6000.0, d:  0.05, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_Y:      {p:  2000.0, d:  0.1, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_KNEE:       {p: 9000.0, d:  0.15, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_P:    {p: 4500.0, d:  0.075, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_R:    {p:  3000.0, d:  0.05, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_P:         {p: 8000.0, d:   0.1, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_R:         {p: 8000.0, d:   0.1, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    CHEST:           {p: 6000.0, d:   0.05, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LARM_SHOULDER_P: {p: 1200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_SHOULDER_R: {p:  500.0, d:   0.05, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    LARM_SHOULDER_Y: {p:  200.0, d:   0.03, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_ELBOW:      {p: 1000.0, d:   0.14, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_WRIST_Y:    {p:  200.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_P:    {p:  300.0, d:   0.02, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_R:    {p:   20.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_SHOULDER_P: {p: 1200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_SHOULDER_R: {p:  500.0, d:   0.05, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    RARM_SHOULDER_Y: {p:  200.0, d:   0.03, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_ELBOW:      {p: 1000.0, d:   0.14, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_WRIST_Y:    {p:  200.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_P:    {p:  300.0, d:   0.02, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_R:    {p:   20.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
 ## force sensor settings
 ## list of force sensorname
   force_torque_sensors:

--- a/hrpsys_gazebo_general/launch/robot_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_general/launch/robot_hrpsys_bringup.launch
@@ -20,7 +20,7 @@
   <!-- hrpsys_gazebo settings -->
   <arg name="SYNCHRONIZED" default="false" />
   <arg name="IOB_SUBSTEPS" default="5" />
-  <arg name="HRPSYS_RATE"  default="200" />
+  <arg name="HRPSYS_RATE"  default="500" />
 
   <env if="$(arg SYNCHRONIZED)"
        name="HRPSYS_GAZEBO_IOB_SYNCHRONIZED" value="1" />

--- a/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup.launch
@@ -24,7 +24,6 @@
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
     <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge" if="$(arg USE_UNSTABLE_RTC)"/>
     <arg name="HRPSYS_PY_NAME" value="samplerobot_hrpsys_config.py" if="$(arg USE_UNSTABLE_RTC)"/>
-    <!-- <arg name="CONF_FILE" default="$(find hrpsys_gazebo_general)/config/SampleRobot.conf" /> -->
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
     <arg name="BASE_LINK" value="WAIST_LINK0" />
   </include>

--- a/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="KINEMATICS_MODE" default="false"/>
   <arg name="SYNCHRONIZED" default="false" />
+  <arg name="USE_UNSTABLE_RTC" default="true"/>
 
   <rosparam command="load"
             file="$(find hrpsys_ros_bridge)/models/SampleRobot_controller_config.yaml" />
@@ -21,8 +22,9 @@
     <arg name="ROBOT_TYPE" value="SampleRobot" />
     <arg name="USE_INSTANCE_NAME" value="true" />
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
-    <arg name="HRPSYS_PY_ARGS" value="--use-unstable-rtc" />
-    <arg name="CONF_FILE" default="$(find hrpsys_gazebo_general)/config/SampleRobot.conf" />
+    <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge" if="$(arg USE_UNSTABLE_RTC)"/>
+    <arg name="HRPSYS_PY_NAME" value="samplerobot_hrpsys_config.py" if="$(arg USE_UNSTABLE_RTC)"/>
+    <!-- <arg name="CONF_FILE" default="$(find hrpsys_gazebo_general)/config/SampleRobot.conf" /> -->
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
     <arg name="BASE_LINK" value="WAIST_LINK0" />
   </include>

--- a/hrpsys_gazebo_general/robot_models/SampleRobot/SampleRobot.urdf.xacro
+++ b/hrpsys_gazebo_general/robot_models/SampleRobot/SampleRobot.urdf.xacro
@@ -29,6 +29,7 @@
           </accel>
         </noise>
       </imu>
+      <pose>0 0 0 1.5708 0 3.14159</pose>
     </sensor>
   </gazebo>
   <!-- add force sensor -->

--- a/hrpsys_gazebo_general/robot_models/SampleRobot/SampleRobot_additional_urdf_setting.sh
+++ b/hrpsys_gazebo_general/robot_models/SampleRobot/SampleRobot_additional_urdf_setting.sh
@@ -15,3 +15,7 @@ sed -i -e 's@continuous@revolute@g' ${OUTPUT_FILE}
 sed -i -e 's@effort="100"@effort="200"@g' ${OUTPUT_FILE}
 ## change max velocity
 sed -i -e 's@velocity="0.5"@velocity="6.0"@g' ${OUTPUT_FILE}
+## change friction
+sed -i -e 's@friction="0"@friction="1"@g' ${OUTPUT_FILE}
+## change damping
+sed -i -e 's@damping="0.2"@damping="1"@g' ${OUTPUT_FILE}

--- a/hrpsys_gazebo_general/src/IOBPlugin.cpp
+++ b/hrpsys_gazebo_general/src/IOBPlugin.cpp
@@ -240,8 +240,8 @@ void IOBPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf) {
                   qt.z = xmlrpc_value_as_double(rot[3]);
                 }
                 fsi.pose = PosePtr(new math::Pose (vtr, qt));
-                this->forceSensors[sensor_name] = fsi;
               }
+              this->forceSensors[sensor_name] = fsi;
             }
           } else {
             ROS_ERROR("Force-Torque sensor: %s has invalid configuration", sensor_name.c_str());


### PR DESCRIPTION
In kinetic, we have to set `use_velocity_feedback` to `false` (because https://github.com/start-jsk/rtmros_gazebo/pull/245).

After setting `use_velocity_feedback` to `false`, we have other problems in simulating samplebot.
```
roslaunch hrpsys_gazebo_general gazebo_samplerobot_no_controllers.launch
rtmlaunch hrpsys_gazebo_general samplerobot_hrpsys_bringup.launch
```
![samplebot_effort](https://user-images.githubusercontent.com/32383525/70601087-a926f080-1c34-11ea-86f2-0bbe5624189b.gif)

1. The robot vibrates.
2. Too many error messages arise. `[hrpEC][1576049965.454544] Timeover: processing time = 2.38[ms]` (but control rate is 200 Hz!)

To solve 1, I set p-gain to smaller value. https://github.com/start-jsk/rtmros_gazebo/commit/3bcc7261220760d28e8391579407d466168b60e6
To solve 2, I had to modify `/opt/ros/kinetic/share/hrpsys_ros_bridge/models/SampleRobot.RobotHardware.conf` (not included in this PR)
from
```exec_cxt.periodic.rate: 500```
to
```exec_cxt.periodic.rate: 200```

(control rate is defined in **4 files**

`SampleRobot.RobotHardware.conf` 
(for execution and control of RobotHardware.rtc)

and

https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/launch/robot_hrpsys_bringup.launch#L23
(for execution of other rtc)(default value)

and

https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/config/SampleRobot.conf#L2
(for control of other rtc)

and

https://github.com/start-jsk/rtmros_gazebo/blob/7389a49529be6d373581779f0aa88563c6e6d2bf/hrpsys_gazebo_general/src/IOBPlugin.cpp#L21
(for IOBPlugin)(default value)
)

With these modification, the robot still cannot walk, so more debugging is needed.
![samplebot_walk](https://user-images.githubusercontent.com/32383525/70601443-5ef23f00-1c35-11ea-99f9-d36d5242633b.gif)
