### PR TITLE
fix .travis.rosinstal to use fkanehiro/hrpsys-base

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -1,0 +1,30 @@
+- git:
+    uri: https://github.com/tork-a/openhrp3-release
+    local-name: openhrp3
+- git:
+    uri: https://github.com/tork-a/hrpsys-release
+    local-name: hrpsys
+## - git:
+##     uri: https://github.com/start-jsk/rtshell_core 
+##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_common
+##     local-name: jsk-ros-pkg/jsk_common
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_recognition
+##     local-name: jsk-ros-pkg/jsk_recognition
+- git:
+    uri: https://github.com/jsk-ros-pkg/jsk_model_tools
+    local-name: jsk-ros-pkg/jsk_model_tools
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_roseus
+##     local-name: jsk-ros-pkg/jsk_roseus
+- svn:
+    uri: https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
+    local-name: jsk-ros-pkg/collada_robots
+- git:
+    uri: https://github.com/start-jsk/rtmros_common
+    local-name: rtm-ros-robotics/rtmros_common
+- git:
+    uri: https://github.com/start-jsk/rtmros_tutorials
+    local-name: rtm-ros-robotics/rtmros_tutorials

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -4,24 +4,6 @@
 - git:
     uri: https://github.com/tork-a/hrpsys-release
     local-name: hrpsys
-## - git:
-##     uri: https://github.com/start-jsk/rtshell_core 
-##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_common
-##     local-name: jsk-ros-pkg/jsk_common
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_recognition
-##     local-name: jsk-ros-pkg/jsk_recognition
-- git:
-    uri: https://github.com/jsk-ros-pkg/jsk_model_tools
-    local-name: jsk-ros-pkg/jsk_model_tools
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_roseus
-##     local-name: jsk-ros-pkg/jsk_roseus
-- svn:
-    uri: https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
-    local-name: jsk-ros-pkg/collada_robots
 - git:
     uri: https://github.com/start-jsk/rtmros_common
     local-name: rtm-ros-robotics/rtmros_common

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -2,7 +2,7 @@
     uri: https://github.com/start-jsk/openhrp3
     local-name: rtm-ros-robotics/openrtm_common/openhrp3
 - git:
-    uri: https://github.com/start-jsk/hrpsys
+    uri: https://github.com/fkanehiro/hrpsys-base
     local-name: rtm-ros-robotics/openrtm_common/hrpsys
 ## - git:
 ##     uri: https://github.com/start-jsk/rtshell_core 

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,8 +1,8 @@
 - git:
-    uri: https://github.com/start-jsk/openhrp3
+    uri: https://github.com/tork-a/openhrp3-release
     local-name: rtm-ros-robotics/openrtm_common/openhrp3
 - git:
-    uri: https://github.com/fkanehiro/hrpsys-base
+    uri: https://github.com/tork-a/hrpsys-release
     local-name: rtm-ros-robotics/openrtm_common/hrpsys
 ## - git:
 ##     uri: https://github.com/start-jsk/rtshell_core 

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -7,6 +7,4 @@
 - git:
     uri: https://github.com/start-jsk/rtmros_common
     local-name: rtm-ros-robotics/rtmros_common
-- git:
-    uri: https://github.com/start-jsk/rtmros_tutorials
-    local-name: rtm-ros-robotics/rtmros_tutorials
+# rtmros_tutorials depends on rtmros_gazebo. So rtmros_tutorials is not included here.

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,9 +1,9 @@
 - git:
     uri: https://github.com/tork-a/openhrp3-release
-    local-name: rtm-ros-robotics/openrtm_common/openhrp3
+    local-name: openhrp3
 - git:
     uri: https://github.com/tork-a/hrpsys-release
-    local-name: rtm-ros-robotics/openrtm_common/hrpsys
+    local-name: hrpsys
 ## - git:
 ##     uri: https://github.com/start-jsk/rtshell_core 
 ##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,7 +1,7 @@
 - git:
     uri: https://github.com/tork-a/openhrp3-release
     version: release/kinetic/openhrp3
-    local-name: rtm-ros-robotics/openrtm_common/openhrp3
+    local-name: openhrp3
 # We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
 # Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
 # Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
@@ -11,4 +11,4 @@
 #    local-name: rtm-ros-robotics/openrtm_common/hrpsys
 - git:
     uri: https://github.com/fkanehiro/hrpsys-base
-    local-name: rtm-ros-robotics/openrtm_common/hrpsys
+    local-name: hrpsys

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,14 @@
+- git:
+    uri: https://github.com/tork-a/openhrp3-release
+    version: release/kinetic/openhrp3
+    local-name: rtm-ros-robotics/openrtm_common/openhrp3
+# We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
+# Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
+# Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
+#- git:
+#    uri: https://github.com/tork-a/hrpsys-release
+#    version: release/kinetic/hrpsys
+#    local-name: rtm-ros-robotics/openrtm_common/hrpsys
+- git:
+    uri: https://github.com/fkanehiro/hrpsys-base
+    local-name: rtm-ros-robotics/openrtm_common/hrpsys

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,25 +17,23 @@ services:
   - docker
 env:
   global:
-    - USE_DOCKER=true
-    - USE_TRAVIS=true
     - ROS_PARALLEL_JOBS="-j1 -l1"
   matrix:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 #matrix:
 #  allow_failures:
-#    - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-#    - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-#    - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+#    - env: USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+#    - env: USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+#    - env: USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 before_install:
   # Install openrtm_aist & add osrf
   - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,13 @@ before_install:
   # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
   # Also, see https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552121026
   - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; export ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src --skip-keys=liburdfdom-dev --skip-keys=liburdfdom-headers-dev"; fi
-script:
-  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
   # On kinetic, drcsim is not released
   - if [ ${ROS_DISTRO} != "kinetic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi
   - if [ $USE_DEB == true ] ; then git clone https://github.com/start-jsk/rtmros_tutorials ~/ros/ws_rtmros_gazebo/src/rtmros_tutorials; fi
-script: source .travis/travis.sh
+script:
+  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
+  - source .travis/travis.sh
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,11 @@ env:
     - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
     - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
     - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+#matrix:
+#  allow_failures:
+#    - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+#    - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+#    - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 before_install:
   # Install openrtm_aist & add osrf
   - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ services:
   - docker
 env:
   global:
-    - ROS_PARALLEL_JOBS="-j1 -l1"
+    - ROS_PARALLEL_JOBS="-j8 -l1"
+    - CATKIN_PARALLEL_TEST_JOBS="-p1 -j8"
   matrix:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ env:
   global:
     - ROS_PARALLEL_JOBS="-j8 -l1"
     - CATKIN_PARALLEL_TEST_JOBS="-p1 -j8"
+    # hrpsys_gazebo_atlas is compiled only. not tested.
+    # Tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
+    # Since rtmros_tutorials depends on rtmros_gazebo, these tests are executed in rtmros_tutorials instead of rtmros_gazebo.
+    - BUILD_PKGS=""
+    - TEST_PKGS="eusgazebo hrp2jsk_moveit_config hrp2jsknt_moveit_config hrp2jsknts_moveit_config hrp2w_moveit_config hrpsys_gazebo_msgs hrpsys_gazebo_general samplerobot_moveit_config staro_moveit_config"
   matrix:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false
@@ -56,7 +61,6 @@ before_install:
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi
   - if [ $USE_DEB == true ] ; then git clone https://github.com/start-jsk/rtmros_tutorials ~/ros/ws_rtmros_gazebo/src/rtmros_tutorials; fi
 script:
-  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
   - source .travis/travis.sh
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
     - USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 #matrix:
 #  allow_failures:
+  # if USE_DEB=false, testing time easily exceeds limits. Reduce the load on the host machine.
 #    - env: USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
 #    - env: USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
 #    - env: USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,20 @@ env:
 before_install:
   # Install openrtm_aist & add osrf
   - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c \"echo \\\"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\\\" > /etc/apt/sources.list.d/gazebo-latest.list\"; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
+  # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
+  # This has a side effect, and we need extra settings.
+  # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076
+  # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
+  # libpcre3-dev requires the same version of libpcrecpp0
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi; fi
+  # Forcely upgrading PCRE makes hrpsys_state_publisher dies:
+  # https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
+  # To avoid this, the following PRs are required:
+  # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
+  # Also, see https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552121026
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; export ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src --skip-keys=liburdfdom-dev --skip-keys=liburdfdom-headers-dev"; fi
+script:
+  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
   # On kinetic, drcsim is not released
   - if [ ${ROS_DISTRO} != "kinetic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ env:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 #matrix:
 #  allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
 #    - env: USE_JENKINS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
 before_install:
   # Install openrtm_aist & add osrf
-  - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
+  - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c \"echo \\\"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\\\" > /etc/apt/sources.list.d/gazebo-latest.list\"; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
   # On kinetic, drcsim is not released
   - if [ ${ROS_DISTRO} != "kinetic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi


### PR DESCRIPTION
Currently `rtmros_gazebo` is tested with https://github.com/start-jsk/hrpsys, which is a deprecated repository.

`.travis.rosinstal` is fixed to use https://github.com/fkanehiro/hrpsys-base.
