### PR TITLE
support melodic compile

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -1,0 +1,30 @@
+- git:
+    uri: https://github.com/tork-a/openhrp3-release
+    local-name: openhrp3
+- git:
+    uri: https://github.com/tork-a/hrpsys-release
+    local-name: hrpsys
+## - git:
+##     uri: https://github.com/start-jsk/rtshell_core 
+##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_common
+##     local-name: jsk-ros-pkg/jsk_common
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_recognition
+##     local-name: jsk-ros-pkg/jsk_recognition
+- git:
+    uri: https://github.com/jsk-ros-pkg/jsk_model_tools
+    local-name: jsk-ros-pkg/jsk_model_tools
+## - git:
+##     uri: https://github.com/jsk-ros-pkg/jsk_roseus
+##     local-name: jsk-ros-pkg/jsk_roseus
+- svn:
+    uri: https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
+    local-name: jsk-ros-pkg/collada_robots
+- git:
+    uri: https://github.com/start-jsk/rtmros_common
+    local-name: rtm-ros-robotics/rtmros_common
+- git:
+    uri: https://github.com/start-jsk/rtmros_tutorials
+    local-name: rtm-ros-robotics/rtmros_tutorials

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,6 +1,6 @@
-- git:
-    uri: https://github.com/tork-a/openhrp3-release
-    local-name: openhrp3
+#- git:
+#    uri: https://github.com/tork-a/openhrp3-release
+#    local-name: openhrp3
 - git:
     uri: https://github.com/tork-a/hrpsys-release
     local-name: hrpsys

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -4,24 +4,6 @@
 - git:
     uri: https://github.com/tork-a/hrpsys-release
     local-name: hrpsys
-## - git:
-##     uri: https://github.com/start-jsk/rtshell_core 
-##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_common
-##     local-name: jsk-ros-pkg/jsk_common
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_recognition
-##     local-name: jsk-ros-pkg/jsk_recognition
-- git:
-    uri: https://github.com/jsk-ros-pkg/jsk_model_tools
-    local-name: jsk-ros-pkg/jsk_model_tools
-## - git:
-##     uri: https://github.com/jsk-ros-pkg/jsk_roseus
-##     local-name: jsk-ros-pkg/jsk_roseus
-- svn:
-    uri: https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
-    local-name: jsk-ros-pkg/collada_robots
 - git:
     uri: https://github.com/start-jsk/rtmros_common
     local-name: rtm-ros-robotics/rtmros_common

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,9 +1,9 @@
 - git:
-    uri: https://github.com/start-jsk/openhrp3
-    local-name: rtm-ros-robotics/openrtm_common/openhrp3
+    uri: https://github.com/tork-a/openhrp3-release
+    local-name: openhrp3
 - git:
-    uri: https://github.com/start-jsk/hrpsys
-    local-name: rtm-ros-robotics/openrtm_common/hrpsys
+    uri: https://github.com/tork-a/hrpsys-release
+    local-name: hrpsys
 ## - git:
 ##     uri: https://github.com/start-jsk/rtshell_core 
 ##     local-name: rtm-ros-robotics/openrtm_common/rtshell_core

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -7,6 +7,4 @@
 - git:
     uri: https://github.com/start-jsk/rtmros_common
     local-name: rtm-ros-robotics/rtmros_common
-- git:
-    uri: https://github.com/start-jsk/rtmros_tutorials
-    local-name: rtm-ros-robotics/rtmros_tutorials
+# rtmros_tutorials depends on rtmros_gazebo. So rtmros_tutorials is not included here.

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,0 +1,14 @@
+- git:
+    uri: https://github.com/tork-a/openhrp3-release
+    version: release/kinetic/openhrp3
+    local-name: openhrp3
+# We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
+# Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
+# Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
+#- git:
+#    uri: https://github.com/tork-a/hrpsys-release
+#    version: release/kinetic/hrpsys
+#    local-name: rtm-ros-robotics/openrtm_common/hrpsys
+- git:
+    uri: https://github.com/fkanehiro/hrpsys-base
+    local-name: hrpsys

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,7 +1,7 @@
-- git:
-    uri: https://github.com/tork-a/openhrp3-release
-    version: release/kinetic/openhrp3
-    local-name: openhrp3
+#- git:
+#    uri: https://github.com/tork-a/openhrp3-release
+#    version: release/kinetic/openhrp3
+#    local-name: openhrp3
 # We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
 # Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
 # Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -1,7 +1,7 @@
-- git:
-    uri: https://github.com/tork-a/openhrp3-release
-    version: release/melodic/openhrp3
-    local-name: openhrp3
+#- git:
+#    uri: https://github.com/tork-a/openhrp3-release
+#    version: release/melodic/openhrp3
+#    local-name: openhrp3
 - git:
     uri: https://github.com/fkanehiro/hrpsys-base
     local-name: hrpsys

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -1,0 +1,7 @@
+- git:
+    uri: https://github.com/tork-a/openhrp3-release
+    version: release/melodic/openhrp3
+    local-name: openhrp3
+- git:
+    uri: https://github.com/fkanehiro/hrpsys-base
+    local-name: hrpsys

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,36 +17,55 @@ services:
   - docker
 env:
   global:
-    - USE_DOCKER=true
-    - USE_TRAVIS=true
-    - ROS_PARALLEL_JOBS="-j1 -l1"
+    - ROS_PARALLEL_JOBS="-j8 -l1"
+    - CATKIN_PARALLEL_TEST_JOBS="-p1 -j8"
+    # hrpsys_gazebo_atlas is compiled only. not tested.
+    # Tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
+    # Since rtmros_tutorials depends on rtmros_gazebo, these tests are executed in rtmros_tutorials instead of rtmros_gazebo.
+    - BUILD_PKGS=""
+    - TEST_PKGS="eusgazebo hrp2jsk_moveit_config hrp2jsknt_moveit_config hrp2jsknts_moveit_config hrp2w_moveit_config hrpsys_gazebo_msgs hrpsys_gazebo_general samplerobot_moveit_config staro_moveit_config"
   matrix:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - USE_JENKINS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
 matrix:
   allow_failures:
-    # - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    # - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    # - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    # if USE_DEB=false, testing time easily exceeds limits. Reduce the load on the host machine.
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    # hrpsys and hrpsys_ros_bridge are not release in melodic
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
 before_install:
   # Install openrtm_aist & add osrf
-  - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
+  - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c \"echo \\\"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\\\" > /etc/apt/sources.list.d/gazebo-latest.list\"; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
+  # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
+  # This has a side effect, and we need extra settings.
+  # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076
+  # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
+  # libpcre3-dev requires the same version of libpcrecpp0
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi; fi
+  # Forcely upgrading PCRE makes hrpsys_state_publisher dies:
+  # https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
+  # To avoid this, the following PRs are required:
+  # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
+  # Also, see https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552121026
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; export ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src --skip-keys=liburdfdom-dev --skip-keys=liburdfdom-headers-dev"; fi
   # On kinetic and melodic, drcsim is not released
   - if [ ${ROS_DISTRO} != "kinetic" ] && [ ${ROS_DISTRO} != "melodic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi
   - if [ $USE_DEB == true ] ; then git clone https://github.com/start-jsk/rtmros_tutorials ~/ros/ws_rtmros_gazebo/src/rtmros_tutorials; fi
-script: source .travis/travis.sh
+script:
+  - source .travis/travis.sh
 notifications:
   email:
     on_success: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ env:
     - ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    # - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+    # - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+    # - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - env: ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
 before_install:
   # Install openrtm_aist & add osrf
   - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - USE_JENKINS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true BEFORE_SCRIPT="pwd; sed -i \"35iadd_definitions(-Wno-deprecated)\" hrpsys/CMakeLists.txt openhrp3/CMakeLists.txt; (cd hrpsys; git diff)"
+    - USE_JENKINS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true BEFORE_SCRIPT="pwd; sed -i \"35iadd_definitions(-Wno-deprecated)\" hrpsys/CMakeLists.txt; (cd hrpsys; git diff)"
 matrix:
   allow_failures:
     # if USE_DEB=false, testing time easily exceeds limits. Reduce the load on the host machine.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,24 +30,24 @@ env:
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin USE_DEB=false
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
     - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - USE_JENKINS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - USE_JENKINS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true BEFORE_SCRIPT="pwd; sed -i \"35iadd_definitions(-Wno-deprecated)\" hrpsys/CMakeLists.txt openhrp3/CMakeLists.txt; (cd hrpsys; git diff)"
 matrix:
   allow_failures:
     # if USE_DEB=false, testing time easily exceeds limits. Reduce the load on the host machine.
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - env: USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
+    - env: USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
+    - env: USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false NOT_TEST_INSTALL=true
     # hrpsys and hrpsys_ros_bridge are not release in melodic
-    - USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - env: USE_DOCKER=true USE_TRAVIS=true ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
 before_install:
   # Install openrtm_aist & add osrf
-  - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c \"echo \\\"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\\\" > /etc/apt/sources.list.d/gazebo-latest.list\"; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
+  - add_scr="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c \"echo \\\"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\\\" > /etc/apt/sources.list.d/gazebo-latest.list\"; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
   # This has a side effect, and we need extra settings.
   # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,19 @@ env:
     - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
     - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=true
     - ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=true
+    - ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
 matrix:
   allow_failures:
     - env: ROS_DISTRO=hydro ROSWS=wstool BUILDER=catkin USE_DEB=false
     - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
     - env: ROS_DISTRO=kinetic ROSWS=wstool BUILDER=catkin USE_DEB=false
+    - env: ROS_DISTRO=melodic ROSWS=wstool BUILDER=catkin USE_DEB=false
 before_install:
   # Install openrtm_aist & add osrf
   - export BEFORE_SCRIPT="sudo apt-get install -qq -y ros-${ROS_DISTRO}-openrtm-aist; sudo -E sh -c 'echo \"deb http://packages.osrfoundation.org/gazebo/ubuntu-stable \`lsb_release -cs\` main\" > /etc/apt/sources.list.d/gazebo-latest.list'; wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -; sudo apt-get update -qq"
-  # On kinetic, drcsim is not released
-  - if [ ${ROS_DISTRO} != "kinetic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
+  # On kinetic and melodic, drcsim is not released
+  - if [ ${ROS_DISTRO} != "kinetic" ] && [ ${ROS_DISTRO} != "melodic" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; sudo apt-get install -qq -y drcsim"; fi
   - if [ $USE_DEB == true ] ; then mkdir -p ~/ros/ws_rtmros_gazebo/src; fi
   - if [ $USE_DEB == true ] ; then git clone https://github.com/start-jsk/rtmros_tutorials ~/ros/ws_rtmros_gazebo/src/rtmros_tutorials; fi
 script: source .travis/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,6 @@ env:
   global:
     - ROS_PARALLEL_JOBS="-j8 -l1"
     - CATKIN_PARALLEL_TEST_JOBS="-p1 -j8"
-    # hrpsys_gazebo_atlas is compiled only. not tested.
-    # Tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
-    # Since rtmros_tutorials depends on rtmros_gazebo, these tests are executed in rtmros_tutorials instead of rtmros_gazebo.
-    - BUILD_PKGS=""
-    - TEST_PKGS="eusgazebo hrp2jsk_moveit_config hrp2jsknt_moveit_config hrp2jsknts_moveit_config hrp2w_moveit_config hrpsys_gazebo_msgs hrpsys_gazebo_general samplerobot_moveit_config staro_moveit_config"
   matrix:
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=true
     #- ROS_DISTRO=groovy ROSWS=rosws BUILDER=rosbuild USE_DEB=false

--- a/hrpsys_gazebo_atlas/test/atlas-hrpsys-ros-bridge-test.l
+++ b/hrpsys_gazebo_atlas/test/atlas-hrpsys-ros-bridge-test.l
@@ -1,6 +1,19 @@
 #!/usr/bin/env roseus
 
-(load "package://hrpsys_ros_bridge_tutorials/test/hrpsys-ros-bridge-test-suits.l")
+;; (load "package://hrpsys_ros_bridge_tutorials/test/hrpsys-ros-bridge-test-suits.l")
+
+;; test for :angle-vector
+(defun tmp-test-seq-angle-vector
+  (rob &optional (func))
+  (mapcar #'(lambda (av)
+              (let ((newav (send rob :angle-vector av)))
+                (send *ri* :angle-vector (send rob :angle-vector) 1000)
+                (send *ri* :wait-interpolation)
+                (if func (setq newav (funcall func)))
+                (eps= (distance (send *ri* :state :potentio-vector) newav) 0.0)))
+          (list (instantiate float-vector (length (send rob :angle-vector)))
+                (send rob :reset-pose)))
+  )
 
 (deftest test-seq-angle-vector
   (assert
@@ -18,6 +31,25 @@
 
 ;; (deftest test-impedance-spring
 ;;   (assert (every #'(lambda (x) (< (abs x) 1.0)) (tmp-test-impedance-spring *atlas* (float-vector 350 -550 900)))))
+
+;; test for simple walking of AutoBalancer.rtc by checking whether the robot tumbled or not
+(defun tmp-test-walk-simple
+  (rob &key (pose-func
+             #'(lambda ()
+                 (send rob :reset-pose)
+                 (send rob :fix-leg-to-coords (make-coords)))))
+  (funcall pose-func)
+  (send *ri* :angle-vector (send rob :angle-vector) 2000)
+  (send *ri* :wait-interpolation)
+  (send *ri* :start-auto-balancer)
+  (send *ri* :go-pos 0.3 0.1 5)
+  (send *ri* :go-velocity 0 0 0)
+  (send *ri* :go-stop)
+  (send *ri* :stop-auto-balancer)
+  (let ((ypr (car (send (send *ri* :state :imucoords) :rpy-angle))))
+    (and (< (rad2deg (abs (elt ypr 1))) 10)
+         (< (rad2deg (abs (elt ypr 2))) 10))
+    ))
 
 (deftest test-walk-simple
   (assert (tmp-test-walk-simple *atlas* :pose-func #'(lambda () (send *atlas* :walk-pose)))))

--- a/hrpsys_gazebo_general/src/AddForcePlugin.cpp
+++ b/hrpsys_gazebo_general/src/AddForcePlugin.cpp
@@ -5,7 +5,10 @@
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
-#include <ignition/math.hh>
+
+#if GAZEBO_MAJOR_VERSION >= 9
+#include <ignition/math/Vector3.hh>
+#endif
 
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
@@ -40,18 +43,39 @@ namespace gazebo
       if (_sdf->HasElement("linkname")) {
 	this->link_name = _sdf->Get<std::string>("linkname");
       }
+#if GAZEBO_MAJOR_VERSION >= 9
       this->force = ignition::math::Vector3d(0, 0, 0);
       if (_sdf->HasElement("force")) {
 	this->force = _sdf->Get<ignition::math::Vector3d>("force");
       }
+#else
+      this->force = math::Vector3(0, 0, 0);
+      if (_sdf->HasElement("force")) {
+	this->force = _sdf->Get<math::Vector3>("force");
+      }
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
       this->torque = ignition::math::Vector3d(0, 0, 0);
       if (_sdf->HasElement("torque")) {
 	this->torque = _sdf->Get<ignition::math::Vector3d>("torque");
       }
+#else
+      this->torque = math::Vector3(0, 0, 0);
+      if (_sdf->HasElement("torque")) {
+	this->torque = _sdf->Get<math::Vector3>("torque");
+      }
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
       this->position = ignition::math::Vector3d(0, 0, 0);
       if(_sdf->HasElement("position")) {
 	this->position = _sdf->Get<ignition::math::Vector3d>("position");
       }
+#else
+      this->position = math::Vector3(0, 0, 0);
+      if(_sdf->HasElement("position")) {
+	this->position = _sdf->Get<math::Vector3>("position");
+      }
+#endif      
 
       // find root link
       this->link = this->model->GetLink(this->link_name);
@@ -99,20 +123,35 @@ namespace gazebo
 
     void SetForceCommand(const geometry_msgs::Wrench::ConstPtr &_msg)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       this->force.X() = _msg->force.x;
       this->force.Y() = _msg->force.y;
       this->force.Z() = _msg->force.z;
       this->torque.X() = _msg->torque.x;
       this->torque.Y() = _msg->torque.y;
       this->torque.Z() = _msg->torque.z;
+#else
+      this->force.x = _msg->force.x;
+      this->force.y = _msg->force.y;
+      this->force.z = _msg->force.z;
+      this->torque.x = _msg->torque.x;
+      this->torque.y = _msg->torque.y;
+      this->torque.z = _msg->torque.z;
+#endif
       gzmsg << "subscribed AddForceCommand. ( force: " << this->force << "  torque: " << this->torque << " )" << std::endl;
     }
 
     void SetForcePosition(const geometry_msgs::Vector3::ConstPtr &_msg)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       this->position.X() = _msg->x;
       this->position.Y() = _msg->y;
       this->position.Z() = _msg->z;
+#else
+      this->position.x = _msg->x;
+      this->position.y = _msg->y;
+      this->position.z = _msg->z;
+#endif
       gzmsg << "subscribed AddForcePosition. ( position: " << this->position << " )" << std::endl;
     }
 
@@ -138,9 +177,15 @@ namespace gazebo
     physics::ModelPtr model;
     std::string link_name;
     std::string obj_name;
+#if GAZEBO_MAJOR_VERSION >= 9
     ignition::math::Vector3d force;
     ignition::math::Vector3d torque;
     ignition::math::Vector3d position;
+#else
+    math::Vector3 force;
+    math::Vector3 torque;
+    math::Vector3 position;
+#endif
     physics::LinkPtr link;
     event::ConnectionPtr updateConnection;
 

--- a/hrpsys_gazebo_general/src/AddForcePlugin.cpp
+++ b/hrpsys_gazebo_general/src/AddForcePlugin.cpp
@@ -5,6 +5,7 @@
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
+#include <ignition/math.hh>
 
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
@@ -39,17 +40,17 @@ namespace gazebo
       if (_sdf->HasElement("linkname")) {
 	this->link_name = _sdf->Get<std::string>("linkname");
       }
-      this->force = math::Vector3(0, 0, 0);
+      this->force = ignition::math::Vector3d(0, 0, 0);
       if (_sdf->HasElement("force")) {
-	this->force = _sdf->Get<math::Vector3>("force");
+	this->force = _sdf->Get<ignition::math::Vector3d>("force");
       }
-      this->torque = math::Vector3(0, 0, 0);
+      this->torque = ignition::math::Vector3d(0, 0, 0);
       if (_sdf->HasElement("torque")) {
-	this->torque = _sdf->Get<math::Vector3>("torque");
+	this->torque = _sdf->Get<ignition::math::Vector3d>("torque");
       }
-      this->position = math::Vector3(0, 0, 0);
+      this->position = ignition::math::Vector3d(0, 0, 0);
       if(_sdf->HasElement("position")) {
-	this->position = _sdf->Get<math::Vector3>("position");
+	this->position = _sdf->Get<ignition::math::Vector3d>("position");
       }
 
       // find root link
@@ -98,20 +99,20 @@ namespace gazebo
 
     void SetForceCommand(const geometry_msgs::Wrench::ConstPtr &_msg)
     {
-      this->force.x = _msg->force.x;
-      this->force.y = _msg->force.y;
-      this->force.z = _msg->force.z;
-      this->torque.x = _msg->torque.x;
-      this->torque.y = _msg->torque.y;
-      this->torque.z = _msg->torque.z;
+      this->force.X() = _msg->force.x;
+      this->force.Y() = _msg->force.y;
+      this->force.Z() = _msg->force.z;
+      this->torque.X() = _msg->torque.x;
+      this->torque.Y() = _msg->torque.y;
+      this->torque.Z() = _msg->torque.z;
       gzmsg << "subscribed AddForceCommand. ( force: " << this->force << "  torque: " << this->torque << " )" << std::endl;
     }
 
     void SetForcePosition(const geometry_msgs::Vector3::ConstPtr &_msg)
     {
-      this->position.x = _msg->x;
-      this->position.y = _msg->y;
-      this->position.z = _msg->z;
+      this->position.X() = _msg->x;
+      this->position.Y() = _msg->y;
+      this->position.Z() = _msg->z;
       gzmsg << "subscribed AddForcePosition. ( position: " << this->position << " )" << std::endl;
     }
 
@@ -137,9 +138,9 @@ namespace gazebo
     physics::ModelPtr model;
     std::string link_name;
     std::string obj_name;
-    math::Vector3 force;
-    math::Vector3 torque;
-    math::Vector3 position;
+    ignition::math::Vector3d force;
+    ignition::math::Vector3d torque;
+    ignition::math::Vector3d position;
     physics::LinkPtr link;
     event::ConnectionPtr updateConnection;
 

--- a/hrpsys_gazebo_general/src/GetVelPlugin.cpp
+++ b/hrpsys_gazebo_general/src/GetVelPlugin.cpp
@@ -22,18 +22,6 @@
 
 #include "PubQueue.h"
 
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
-#endif
-
 
 namespace gazebo
 {
@@ -102,7 +90,7 @@ namespace gazebo
     // Called by the world update start event
     void OnUpdate(const common::UpdateInfo & /*_info*/)
     {
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       common::Time curTime = this->world->SimTime();
 #else
       common::Time curTime = this->world->GetSimTime();
@@ -117,39 +105,41 @@ namespace gazebo
     {
       geometry_msgs::TwistStamped _twist;
       geometry_msgs::PoseStamped _pose;
+#if GAZEBO_MAJOR_VERSION >= 9
       ignition::math::Vector3d linear_vel;
       ignition::math::Vector3d angular_vel;
       ignition::math::Vector3d linear_accel;
       ignition::math::Vector3d angular_accel;
       ignition::math::Pose3d pose;
+#else
+      math::Vector3 linear_vel;
+      math::Vector3 angular_vel;
+      math::Vector3 linear_accel;
+      math::Vector3 angular_accel;
+      math::Pose pose;
+#endif
       _twist.header.stamp = ros::Time(_curTime.sec, _curTime.nsec);
       _pose.header.stamp = ros::Time(_curTime.sec, _curTime.nsec);
 
       // set rel vel
 #if GAZEBO_MAJOR_VERSION >= 9
       linear_vel = this->model->RelativeLinearVel();
-#else
-      linear_vel = this->model->GetRelativeLinearVel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.linear.x = linear_vel.X();
       _twist.twist.linear.y = linear_vel.Y();
       _twist.twist.linear.z = linear_vel.Z();
 #else
+      linear_vel = this->model->GetRelativeLinearVel();
       _twist.twist.linear.x = linear_vel.x;
       _twist.twist.linear.y = linear_vel.y;
       _twist.twist.linear.z = linear_vel.z;
 #endif
 #if GAZEBO_MAJOR_VERSION >= 9
       angular_vel = this->model->RelativeAngularVel();
-#else
-      angular_vel = this->model->GetRelativeAngularVel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.angular.x = angular_vel.X();
       _twist.twist.angular.y = angular_vel.Y();
       _twist.twist.angular.z = angular_vel.Z();
 #else
+      angular_vel = this->model->GetRelativeAngularVel();
       _twist.twist.angular.x = angular_vel.x;
       _twist.twist.angular.y = angular_vel.y;
       _twist.twist.angular.z = angular_vel.z;
@@ -160,28 +150,22 @@ namespace gazebo
       // set abs vel
 #if GAZEBO_MAJOR_VERSION >= 9
       linear_vel = this->model->WorldLinearVel();
-#else
-      linear_vel = this->model->GetWorldLinearVel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.linear.x = linear_vel.X();
       _twist.twist.linear.y = linear_vel.Y();
       _twist.twist.linear.z = linear_vel.Z();
 #else
+      linear_vel = this->model->GetWorldLinearVel();
       _twist.twist.linear.x = linear_vel.x;
       _twist.twist.linear.y = linear_vel.y;
       _twist.twist.linear.z = linear_vel.z;
 #endif
 #if GAZEBO_MAJOR_VERSION >= 9
       angular_vel = this->model->WorldAngularVel();
-#else
-      angular_vel = this->model->GetWorldAngularVel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.angular.x = angular_vel.X();
       _twist.twist.angular.y = angular_vel.Y();
       _twist.twist.angular.z = angular_vel.Z();
 #else
+      angular_vel = this->model->GetWorldAngularVel();
       _twist.twist.angular.x = angular_vel.x;
       _twist.twist.angular.y = angular_vel.y;
       _twist.twist.angular.z = angular_vel.z;
@@ -192,14 +176,11 @@ namespace gazebo
       // set rel accel
 #if GAZEBO_MAJOR_VERSION >= 9
       linear_accel = this->model->RelativeLinearAccel();
-#else
-      linear_accel = this->model->GetRelativeLinearAccel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.linear.x = linear_accel.X();
       _twist.twist.linear.y = linear_accel.Y();
       _twist.twist.linear.z = linear_accel.Z();
 #else
+      linear_accel = this->model->GetRelativeLinearAccel();
       _twist.twist.linear.x = linear_accel.x;
       _twist.twist.linear.y = linear_accel.y;
       _twist.twist.linear.z = linear_accel.z;
@@ -209,7 +190,7 @@ namespace gazebo
 #else
       angular_accel = this->model->GetRelativeAngularAccel();
 #endif
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       _twist.twist.angular.x = angular_accel.X();
       _twist.twist.angular.y = angular_accel.Y();
       _twist.twist.angular.z = angular_accel.Z();
@@ -224,28 +205,22 @@ namespace gazebo
       // set abs accel
 #if GAZEBO_MAJOR_VERSION >= 9
       linear_accel = this->model->WorldLinearAccel();
-#else
-      linear_accel = this->model->GetWorldLinearAccel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.linear.x = linear_accel.X();
       _twist.twist.linear.y = linear_accel.Y();
       _twist.twist.linear.z = linear_accel.Z();
 #else
+      linear_accel = this->model->GetWorldLinearAccel();
       _twist.twist.linear.x = linear_accel.x;
       _twist.twist.linear.y = linear_accel.y;
       _twist.twist.linear.z = linear_accel.z;
 #endif
 #if GAZEBO_MAJOR_VERSION >= 9
       angular_accel = this->model->WorldAngularAccel();
-#else
-      angular_accel = this->model->GetWorldAngularAccel();
-#endif
-#if GAZEBO_MAJOR_VERSION >= 7
       _twist.twist.angular.x = angular_accel.X();
       _twist.twist.angular.y = angular_accel.Y();
       _twist.twist.angular.z = angular_accel.Z();
 #else
+      angular_accel = this->model->GetWorldAngularAccel();
       _twist.twist.angular.x = angular_accel.x;
       _twist.twist.angular.y = angular_accel.y;
       _twist.twist.angular.z = angular_accel.z;
@@ -256,11 +231,7 @@ namespace gazebo
       // set pose
 #if GAZEBO_MAJOR_VERSION >= 9
       pose = this->link->WorldCoGPose();
-#else
-      pose = this->link->GetWorldCoGPose();
-#endif
       // pose = this->link->GetWorldPose();
-#if GAZEBO_MAJOR_VERSION >= 7
       _pose.pose.position.x = pose.Pos().X();
       _pose.pose.position.y = pose.Pos().Y();
       _pose.pose.position.z = pose.Pos().Z();
@@ -269,6 +240,8 @@ namespace gazebo
       _pose.pose.orientation.z = pose.Rot().Z();
       _pose.pose.orientation.w = pose.Rot().W();
 #else
+      pose = this->link->GetWorldCoGPose();
+      // pose = this->link->GetWorldPose();
       _pose.pose.position.x = pose.pos.x;
       _pose.pose.position.y = pose.pos.y;
       _pose.pose.position.z = pose.pos.z;

--- a/hrpsys_gazebo_general/src/GetVelPlugin.cpp
+++ b/hrpsys_gazebo_general/src/GetVelPlugin.cpp
@@ -22,6 +22,18 @@
 
 #include "PubQueue.h"
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#else
+namespace ignition::math
+{
+  using equal = gazebo::math::equal;
+  using clamp = gazebo::math::clamp;
+  using Pose3d = gazebo::math::Pose;
+  using Vector3d = gazebo::math::Vector3;
+  using Quaterniond = gazebo::math::Quaterion;
+}
+#endif
+
 
 namespace gazebo
 {
@@ -90,7 +102,11 @@ namespace gazebo
     // Called by the world update start event
     void OnUpdate(const common::UpdateInfo & /*_info*/)
     {
+#if GAZEBO_MAJOR_VERSION >= 7
+      common::Time curTime = this->world->SimTime();
+#else
       common::Time curTime = this->world->GetSimTime();
+#endif
 
       // publish topics
       this->PublishVel(curTime);
@@ -101,65 +117,158 @@ namespace gazebo
     {
       geometry_msgs::TwistStamped _twist;
       geometry_msgs::PoseStamped _pose;
-      math::Vector3 linear_vel;
-      math::Vector3 angular_vel;
-      math::Vector3 linear_accel;
-      math::Vector3 angular_accel;
-      math::Pose pose;
+      ignition::math::Vector3d linear_vel;
+      ignition::math::Vector3d angular_vel;
+      ignition::math::Vector3d linear_accel;
+      ignition::math::Vector3d angular_accel;
+      ignition::math::Pose3d pose;
       _twist.header.stamp = ros::Time(_curTime.sec, _curTime.nsec);
       _pose.header.stamp = ros::Time(_curTime.sec, _curTime.nsec);
 
       // set rel vel
+#if GAZEBO_MAJOR_VERSION >= 9
+      linear_vel = this->model->RelativeLinearVel();
+#else
       linear_vel = this->model->GetRelativeLinearVel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.linear.x = linear_vel.X();
+      _twist.twist.linear.y = linear_vel.Y();
+      _twist.twist.linear.z = linear_vel.Z();
+#else
       _twist.twist.linear.x = linear_vel.x;
       _twist.twist.linear.y = linear_vel.y;
       _twist.twist.linear.z = linear_vel.z;
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
+      angular_vel = this->model->RelativeAngularVel();
+#else
       angular_vel = this->model->GetRelativeAngularVel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.angular.x = angular_vel.X();
+      _twist.twist.angular.y = angular_vel.Y();
+      _twist.twist.angular.z = angular_vel.Z();
+#else
       _twist.twist.angular.x = angular_vel.x;
       _twist.twist.angular.y = angular_vel.y;
       _twist.twist.angular.z = angular_vel.z;
+#endif
       // publish rel vel
       this->pubRelVelQueue->push(_twist, this->pubRelVel);
 
       // set abs vel
+#if GAZEBO_MAJOR_VERSION >= 9
+      linear_vel = this->model->WorldLinearVel();
+#else
       linear_vel = this->model->GetWorldLinearVel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.linear.x = linear_vel.X();
+      _twist.twist.linear.y = linear_vel.Y();
+      _twist.twist.linear.z = linear_vel.Z();
+#else
       _twist.twist.linear.x = linear_vel.x;
       _twist.twist.linear.y = linear_vel.y;
       _twist.twist.linear.z = linear_vel.z;
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
+      angular_vel = this->model->WorldAngularVel();
+#else
       angular_vel = this->model->GetWorldAngularVel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.angular.x = angular_vel.X();
+      _twist.twist.angular.y = angular_vel.Y();
+      _twist.twist.angular.z = angular_vel.Z();
+#else
       _twist.twist.angular.x = angular_vel.x;
       _twist.twist.angular.y = angular_vel.y;
       _twist.twist.angular.z = angular_vel.z;
+#endif
       // publish abs vel
       this->pubAbsVelQueue->push(_twist, this->pubAbsVel);
 
       // set rel accel
+#if GAZEBO_MAJOR_VERSION >= 9
+      linear_accel = this->model->RelativeLinearAccel();
+#else
       linear_accel = this->model->GetRelativeLinearAccel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.linear.x = linear_accel.X();
+      _twist.twist.linear.y = linear_accel.Y();
+      _twist.twist.linear.z = linear_accel.Z();
+#else
       _twist.twist.linear.x = linear_accel.x;
       _twist.twist.linear.y = linear_accel.y;
       _twist.twist.linear.z = linear_accel.z;
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
+      angular_accel = this->model->RelativeAngularAccel();
+#else
       angular_accel = this->model->GetRelativeAngularAccel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.angular.x = angular_accel.X();
+      _twist.twist.angular.y = angular_accel.Y();
+      _twist.twist.angular.z = angular_accel.Z();
+#else
       _twist.twist.angular.x = angular_accel.x;
       _twist.twist.angular.y = angular_accel.y;
       _twist.twist.angular.z = angular_accel.z;
+#endif
       // publish rel accel
       this->pubRelAccelQueue->push(_twist, this->pubRelAccel);
 
       // set abs accel
+#if GAZEBO_MAJOR_VERSION >= 9
+      linear_accel = this->model->WorldLinearAccel();
+#else
       linear_accel = this->model->GetWorldLinearAccel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.linear.x = linear_accel.X();
+      _twist.twist.linear.y = linear_accel.Y();
+      _twist.twist.linear.z = linear_accel.Z();
+#else
       _twist.twist.linear.x = linear_accel.x;
       _twist.twist.linear.y = linear_accel.y;
       _twist.twist.linear.z = linear_accel.z;
+#endif
+#if GAZEBO_MAJOR_VERSION >= 9
+      angular_accel = this->model->WorldAngularAccel();
+#else
       angular_accel = this->model->GetWorldAngularAccel();
+#endif
+#if GAZEBO_MAJOR_VERSION >= 7
+      _twist.twist.angular.x = angular_accel.X();
+      _twist.twist.angular.y = angular_accel.Y();
+      _twist.twist.angular.z = angular_accel.Z();
+#else
       _twist.twist.angular.x = angular_accel.x;
       _twist.twist.angular.y = angular_accel.y;
       _twist.twist.angular.z = angular_accel.z;
+#endif
       // publish abs accel
       this->pubAbsAccelQueue->push(_twist, this->pubAbsAccel);
 
       // set pose
+#if GAZEBO_MAJOR_VERSION >= 9
+      pose = this->link->WorldCoGPose();
+#else
       pose = this->link->GetWorldCoGPose();
+#endif
       // pose = this->link->GetWorldPose();
+#if GAZEBO_MAJOR_VERSION >= 7
+      _pose.pose.position.x = pose.Pos().X();
+      _pose.pose.position.y = pose.Pos().Y();
+      _pose.pose.position.z = pose.Pos().Z();
+      _pose.pose.orientation.x = pose.Rot().X();
+      _pose.pose.orientation.y = pose.Rot().Y();
+      _pose.pose.orientation.z = pose.Rot().Z();
+      _pose.pose.orientation.w = pose.Rot().W();
+#else
       _pose.pose.position.x = pose.pos.x;
       _pose.pose.position.y = pose.pos.y;
       _pose.pose.position.z = pose.pos.z;
@@ -167,6 +276,7 @@ namespace gazebo
       _pose.pose.orientation.y = pose.rot.y;
       _pose.pose.orientation.z = pose.rot.z;
       _pose.pose.orientation.w = pose.rot.w;
+#endif
       // publish pose
       this->pubPoseQueue->push(_pose, this->pubPose);
     }

--- a/hrpsys_gazebo_general/src/IOBPlugin.h
+++ b/hrpsys_gazebo_general/src/IOBPlugin.h
@@ -18,7 +18,7 @@
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 #include <ignition/math/Pose3.hh>
 #else
 #include <gazebo/math/gzmath.hh>
@@ -46,23 +46,11 @@
 
 #include "PubQueue.h"
 
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
 #include <memory>
 using std::shared_ptr;
 #else
 using boost::shared_ptr;
-#endif
-
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
 #endif
 
 namespace gazebo
@@ -70,7 +58,11 @@ namespace gazebo
   typedef shared_ptr< sensors::ImuSensor > ImuSensorPtr;
   typedef hrpsys_gazebo_msgs::JointCommand JointCommand;
   typedef hrpsys_gazebo_msgs::RobotState RobotState;
+#if GAZEBO_MAJOR_VERSION >= 9
   typedef shared_ptr< ignition::math::Pose3d > PosePtr;
+#else
+  typedef shared_ptr< math::Pose > PosePtr;
+#endif
 
   class IOBPlugin : public ModelPlugin
   {

--- a/hrpsys_gazebo_general/src/IOBPlugin.h
+++ b/hrpsys_gazebo_general/src/IOBPlugin.h
@@ -18,7 +18,11 @@
 #include <boost/thread.hpp>
 #include <boost/thread/condition.hpp>
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#include <ignition/math/Pose3.hh>
+#else
 #include <gazebo/math/gzmath.hh>
+#endif
 #include <gazebo/physics/physics.hh>
 #include <gazebo/physics/PhysicsTypes.hh>
 #include <gazebo/transport/TransportTypes.hh>
@@ -49,12 +53,24 @@ using std::shared_ptr;
 using boost::shared_ptr;
 #endif
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#else
+namespace ignition::math
+{
+  using equal = gazebo::math::equal;
+  using clamp = gazebo::math::clamp;
+  using Pose3d = gazebo::math::Pose;
+  using Vector3d = gazebo::math::Vector3;
+  using Quaterniond = gazebo::math::Quaterion;
+}
+#endif
+
 namespace gazebo
 {
   typedef shared_ptr< sensors::ImuSensor > ImuSensorPtr;
   typedef hrpsys_gazebo_msgs::JointCommand JointCommand;
   typedef hrpsys_gazebo_msgs::RobotState RobotState;
-  typedef shared_ptr< math::Pose > PosePtr;
+  typedef shared_ptr< ignition::math::Pose3d > PosePtr;
 
   class IOBPlugin : public ModelPlugin
   {

--- a/hrpsys_gazebo_general/src/LIPPlugin.cpp
+++ b/hrpsys_gazebo_general/src/LIPPlugin.cpp
@@ -22,18 +22,6 @@
 
 #include "PubQueue.h"
 
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
-#endif
-
 namespace gazebo
 {
   class LIPPlugin : public ModelPlugin
@@ -126,9 +114,15 @@ namespace gazebo
 
     bool SwitchFootCallback(hrpsys_gazebo_msgs::LIPSwitchFootRequest &req, hrpsys_gazebo_msgs::LIPSwitchFootResponse &res)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       ignition::math::Pose3d base_pose(req.command.foot_position.x, req.command.foot_position.y, req.command.foot_position.z, 0, 0, 0);
       ignition::math::Pose3d mass_pose;
       ignition::math::Vector3d mass_velocity(req.command.mass_velocity.x, req.command.mass_velocity.y, req.command.mass_velocity.z);
+#else
+      math::Pose base_pose(req.command.foot_position.x, req.command.foot_position.y, req.command.foot_position.z, 0, 0, 0);
+      math::Pose mass_pose;
+      math::Vector3 mass_velocity(req.command.mass_velocity.x, req.command.mass_velocity.y, req.command.mass_velocity.z);
+#endif
 
 #if GAZEBO_MAJOR_VERSION >= 9
       mass_pose = this->mass_link_->WorldPose();
@@ -139,15 +133,15 @@ namespace gazebo
 #if GAZEBO_MAJOR_VERSION >= 9
         mass_velocity = this->mass_link_->WorldLinearVel();
 #else
-	mass_velocity = this->mass_link_->GetWorldLinearVel();
-#endif	
+        mass_velocity = this->mass_link_->GetWorldLinearVel();
+#endif
       }
 
       ROS_INFO_STREAM_THROTTLE(1.0, "[LIP command]  switch foot command" << std::endl
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
                                << "  foot_pos: " << base_pose.Pos() << std::endl
 #else
-			       << "  foot_pos: " << base_pose.pos << std::endl
+                               << "  foot_pos: " << base_pose.pos << std::endl
 #endif
                                << "  mass_vel: (keep: " << bool(req.command.keep_mass_velocity) << ") " << mass_velocity);
 
@@ -157,7 +151,7 @@ namespace gazebo
       this->root_y_joint_->SetVelocity(0, 0);
       this->linear_joint_->SetVelocity(0, 0);
       // set position and velocity
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
       this->model_->SetWorldPose(base_pose);
 #else
       this->model_->SetWorldPose(base_pose, this->base_link_);
@@ -170,12 +164,18 @@ namespace gazebo
 
     bool SetStateCallback(hrpsys_gazebo_msgs::LIPSetStateRequest &req, hrpsys_gazebo_msgs::LIPSetStateResponse &res)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       ignition::math::Pose3d base_pose(req.command.foot_position.x, req.command.foot_position.y, req.command.foot_position.z, 0, 0, 0);
       ignition::math::Pose3d mass_pose(req.command.mass_position.x, req.command.mass_position.y, req.command.mass_position.z, 0, 0, 0);
       ignition::math::Vector3d mass_velocity(req.command.mass_velocity.x, req.command.mass_velocity.y, req.command.mass_velocity.z);
+#else
+      math::Pose base_pose(req.command.foot_position.x, req.command.foot_position.y, req.command.foot_position.z, 0, 0, 0);
+      math::Pose mass_pose(req.command.mass_position.x, req.command.mass_position.y, req.command.mass_position.z, 0, 0, 0);
+      math::Vector3 mass_velocity(req.command.mass_velocity.x, req.command.mass_velocity.y, req.command.mass_velocity.z);
+#endif
 
       ROS_INFO_STREAM_THROTTLE(1.0, "[LIP command]  set state command" << std::endl
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
                                << "  foot_pos: " << base_pose.Pos() << std::endl
                                << "  mass_pos: " << mass_pose.Pos() << std::endl
 #else
@@ -190,7 +190,7 @@ namespace gazebo
       this->root_y_joint_->SetVelocity(0, 0);
       this->linear_joint_->SetVelocity(0, 0);
       // set position and velocity
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
       this->model_->SetWorldPose(base_pose);
 #else
       this->model_->SetWorldPose(base_pose, this->base_link_);
@@ -213,27 +213,25 @@ namespace gazebo
 #if GAZEBO_MAJOR_VERSION >= 9
       ignition::math::Pose3d base_pose = this->base_link_->WorldPose();;
       ignition::math::Pose3d mass_pose = this->mass_link_->WorldPose();;
-#else
-      ignition::math::Pose3d base_pose = this->base_link_->GetWorldPose();;
-      ignition::math::Pose3d mass_pose = this->mass_link_->GetWorldPose();;
-#endif      
-#if GAZEBO_MAJOR_VERSION >= 7
       double mass_z = mass_pose.Pos().Z();
       double mass_length = (base_pose.Pos() - mass_pose.Pos()).Length();
-#else
-      double mass_z = mass_pose.pos.z;
-      double mass_length = (base_pose.pos - mass_pose.pos).GetLength();
-#endif
 
-#if GAZEBO_MAJOR_VERSION >= 9
       double mass = this->mass_link_->GetInertial()->Mass();
 #else
+      math::Pose base_pose = this->base_link_->GetWorldPose();;
+      math::Pose mass_pose = this->mass_link_->GetWorldPose();;
+      double mass_z = mass_pose.pos.z;
+      double mass_length = (base_pose.pos - mass_pose.pos).GetLength();
       double mass = this->mass_link_->GetInertial()->GetMass();
 #endif
       double gravity = 9.81;
       double force = mass * gravity * mass_length / mass_z;
       double force_limit = this->linear_joint_->GetEffortLimit(0);
+#if GAZEBO_MAJOR_VERSION >= 9
       force = ignition::math::clamp(force, -force_limit, force_limit);
+#else
+      force = math::clamp(force, -force_limit, force_limit);
+#endif
 
       ROS_INFO_STREAM_THROTTLE(1.0, "[LIP control]  " << "mg: " << mass * gravity << "  z: " << mass_z << "  l: " << mass_length << "  f: " << force);
 
@@ -248,17 +246,16 @@ namespace gazebo
       ignition::math::Pose3d mass_pose = this->mass_link_->WorldPose();;
       ignition::math::Vector3d mass_velocity = this->mass_link_->WorldLinearVel();
 #else
-      ignition::math::Pose3d base_pose = this->base_link_->GetWorldPose();;
-      ignition::math::Pose3d mass_pose = this->mass_link_->GetWorldPose();;
-      ignition::math::Vector3d mass_velocity = this->mass_link_->GetWorldLinearVel();
+      math::Pose base_pose = this->base_link_->GetWorldPose();;
+      math::Pose mass_pose = this->mass_link_->GetWorldPose();;
+      math::Vector3 mass_velocity = this->mass_link_->GetWorldLinearVel();
 #endif
-
 
       std_msgs::Header tmp_header;
       tmp_header.stamp = ros::Time::now();
       state.header = tmp_header;
 
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       state.foot_position.x = base_pose.Pos().X();
       state.foot_position.y = base_pose.Pos().Y();
       state.foot_position.z = base_pose.Pos().Z();
@@ -283,6 +280,7 @@ namespace gazebo
       state.mass_velocity.y = mass_velocity.y;
       state.mass_velocity.z = mass_velocity.z;
 #endif
+
       this->state_pub_queue_->push(state, this->state_pub_);
     }
 

--- a/hrpsys_gazebo_general/src/PubQueue.h
+++ b/hrpsys_gazebo_general/src/PubQueue.h
@@ -27,7 +27,7 @@
 
 #include <ros/ros.h>
 
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
 using std::shared_ptr;
 #else
 using boost::shared_ptr;

--- a/hrpsys_gazebo_general/src/PubTfPlugin.cpp
+++ b/hrpsys_gazebo_general/src/PubTfPlugin.cpp
@@ -6,7 +6,7 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Time.hh>
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 #include <ignition/math/Pose3.hh>
 #endif
 
@@ -21,17 +21,6 @@
 
 #include "PubQueue.h"
 
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
-#endif
 
 namespace gazebo
 {
@@ -88,7 +77,7 @@ namespace gazebo
     // Called by the world update start event
     void OnUpdate(const common::UpdateInfo & /*_info*/)
     {
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       common::Time curTime = this->world->SimTime();
 #else
       common::Time curTime = this->world->GetSimTime();
@@ -101,7 +90,11 @@ namespace gazebo
     // Publish function
     void PublishTf(const common::Time &_curTime)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       ignition::math::Pose3d pose;
+#else
+      math::Pose pose;
+#endif
       tf::Transform transform;
 
       // set pose
@@ -113,7 +106,7 @@ namespace gazebo
       pose = this->link->GetWorldPose();
       transform.setOrigin(tf::Vector3(pose.pos.x, pose.pos.y, pose.pos.z));
       tf::Quaternion q(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
-#endif  
+#endif
       transform.setRotation(q);
       // publish pose
       this->br.sendTransform(tf::StampedTransform(transform, ros::Time(_curTime.sec, _curTime.nsec), "gazebo_world", this->link_name));

--- a/hrpsys_gazebo_general/src/PubTfPlugin.cpp
+++ b/hrpsys_gazebo_general/src/PubTfPlugin.cpp
@@ -6,6 +6,9 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Time.hh>
+#if GAZEBO_MAJOR_VERSION >= 7
+#include <ignition/math/Pose3.hh>
+#endif
 
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
@@ -18,6 +21,17 @@
 
 #include "PubQueue.h"
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#else
+namespace ignition::math
+{
+  using equal = gazebo::math::equal;
+  using clamp = gazebo::math::clamp;
+  using Pose3d = gazebo::math::Pose;
+  using Vector3d = gazebo::math::Vector3;
+  using Quaterniond = gazebo::math::Quaterion;
+}
+#endif
 
 namespace gazebo
 {
@@ -74,7 +88,11 @@ namespace gazebo
     // Called by the world update start event
     void OnUpdate(const common::UpdateInfo & /*_info*/)
     {
+#if GAZEBO_MAJOR_VERSION >= 7
+      common::Time curTime = this->world->SimTime();
+#else
       common::Time curTime = this->world->GetSimTime();
+#endif
 
       // publish topics
       this->PublishTf(curTime);
@@ -83,13 +101,19 @@ namespace gazebo
     // Publish function
     void PublishTf(const common::Time &_curTime)
     {
-      math::Pose pose;
+      ignition::math::Pose3d pose;
       tf::Transform transform;
 
       // set pose
+#if GAZEBO_MAJOR_VERSION >= 9
+      pose = this->link->WorldPose();
+      transform.setOrigin(tf::Vector3(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z()));
+      tf::Quaternion q(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+#else
       pose = this->link->GetWorldPose();
       transform.setOrigin(tf::Vector3(pose.pos.x, pose.pos.y, pose.pos.z));
       tf::Quaternion q(pose.rot.x, pose.rot.y, pose.rot.z, pose.rot.w);
+#endif  
       transform.setRotation(q);
       // publish pose
       this->br.sendTransform(tf::StampedTransform(transform, ros::Time(_curTime.sec, _curTime.nsec), "gazebo_world", this->link_name));

--- a/hrpsys_gazebo_general/src/SetVelPlugin.cpp
+++ b/hrpsys_gazebo_general/src/SetVelPlugin.cpp
@@ -6,6 +6,12 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Pose3.hh>
+#endif
+
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
 #include <ros/advertise_options.h>
@@ -17,6 +23,17 @@
 #include <geometry_msgs/Wrench.h>
 #include <std_msgs/String.h>
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#else
+namespace ignition::math
+{
+  using equal = gazebo::math::equal;
+  using clamp = gazebo::math::clamp;
+  using Pose3d = gazebo::math::Pose;
+  using Vector3d = gazebo::math::Vector3;
+  using Quaterniond = gazebo::math::Quaterion;
+}
+#endif
 
 namespace gazebo
 {
@@ -96,12 +113,21 @@ namespace gazebo
 
     void SetVelCommand(const geometry_msgs::Twist::ConstPtr &_msg)
     {
+#if GAZEBO_MAJOR_VERSION >= 7
+      this->linear_vel.X() = _msg->linear.x;
+      this->linear_vel.Y() = _msg->linear.y;
+      this->linear_vel.Z() = _msg->linear.z;
+      this->angular_vel.X() = _msg->angular.x;
+      this->angular_vel.Y() = _msg->angular.y;
+      this->angular_vel.Z() = _msg->angular.z;
+#else
       this->linear_vel.x = _msg->linear.x;
       this->linear_vel.y = _msg->linear.y;
       this->linear_vel.z = _msg->linear.z;
       this->angular_vel.x = _msg->angular.x;
       this->angular_vel.y = _msg->angular.y;
       this->angular_vel.z = _msg->angular.z;
+#endif
       this->set_vel_flag = true;
       gzmsg << "subscribed SetVelCommand. ( linear: " << this->linear_vel << "  angular: " << this->angular_vel << " )" << std::endl;
       if (!this->apply_in_gazebo_loop) {
@@ -112,12 +138,16 @@ namespace gazebo
 
     void SetPoseCommand(const geometry_msgs::Pose::ConstPtr &_msg)
     {
-      this->model->SetLinearVel(math::Vector3(0, 0, 0));
-      this->model->SetAngularVel(math::Vector3(0, 0, 0));
-      this->pose.Set(math::Vector3(_msg->position.x, _msg->position.y, _msg->position.z),
-                     math::Quaternion(_msg->orientation.w, _msg->orientation.x, _msg->orientation.y, _msg->orientation.z));
+      this->model->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
+      this->model->SetAngularVel(ignition::math::Vector3d(0, 0, 0));
+      this->pose.Set(ignition::math::Vector3d(_msg->position.x, _msg->position.y, _msg->position.z),
+                     ignition::math::Quaterniond(_msg->orientation.w, _msg->orientation.x, _msg->orientation.y, _msg->orientation.z));
       this->set_pose_flag = true;
+#if GAZEBO_MAJOR_VERSION >= 7
+      gzdbg << "subscribed SetPoseCommand. ( position: " << this->pose.Pos() << "  orientation: " << this->pose.Rot() << " )" << std::endl;
+#else
       gzdbg << "subscribed SetPoseCommand. ( position: " << this->pose.pos << "  orientation: " << this->pose.rot << " )" << std::endl;
+#endif
       if (!this->apply_in_gazebo_loop) {
         // this->model->SetLinkWorldPose(this->pose, this->link);
 #if __cplusplus >= 201103L
@@ -159,9 +189,9 @@ namespace gazebo
     physics::ModelPtr model;
     std::string obj_name;
     std::string link_name;
-    math::Vector3 linear_vel;
-    math::Vector3 angular_vel;
-    math::Pose pose;
+    ignition::math::Vector3d linear_vel;
+    ignition::math::Vector3d angular_vel;
+    ignition::math::Pose3d pose;
     physics::LinkPtr link;
     event::ConnectionPtr updateConnection;
     bool set_pose_flag;

--- a/hrpsys_gazebo_general/src/SetVelPlugin.cpp
+++ b/hrpsys_gazebo_general/src/SetVelPlugin.cpp
@@ -6,7 +6,7 @@
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Pose3.hh>
@@ -23,17 +23,6 @@
 #include <geometry_msgs/Wrench.h>
 #include <std_msgs/String.h>
 
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
-#endif
 
 namespace gazebo
 {
@@ -113,7 +102,7 @@ namespace gazebo
 
     void SetVelCommand(const geometry_msgs::Twist::ConstPtr &_msg)
     {
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       this->linear_vel.X() = _msg->linear.x;
       this->linear_vel.Y() = _msg->linear.y;
       this->linear_vel.Z() = _msg->linear.z;
@@ -138,19 +127,26 @@ namespace gazebo
 
     void SetPoseCommand(const geometry_msgs::Pose::ConstPtr &_msg)
     {
+#if GAZEBO_MAJOR_VERSION >= 9
       this->model->SetLinearVel(ignition::math::Vector3d(0, 0, 0));
       this->model->SetAngularVel(ignition::math::Vector3d(0, 0, 0));
       this->pose.Set(ignition::math::Vector3d(_msg->position.x, _msg->position.y, _msg->position.z),
                      ignition::math::Quaterniond(_msg->orientation.w, _msg->orientation.x, _msg->orientation.y, _msg->orientation.z));
+#else
+      this->model->SetLinearVel(math::Vector3(0, 0, 0));
+      this->model->SetAngularVel(math::Vector3(0, 0, 0));
+      this->pose.Set(math::Vector3(_msg->position.x, _msg->position.y, _msg->position.z),
+                     math::Quaternion(_msg->orientation.w, _msg->orientation.x, _msg->orientation.y, _msg->orientation.z));
+#endif
       this->set_pose_flag = true;
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
       gzdbg << "subscribed SetPoseCommand. ( position: " << this->pose.Pos() << "  orientation: " << this->pose.Rot() << " )" << std::endl;
 #else
       gzdbg << "subscribed SetPoseCommand. ( position: " << this->pose.pos << "  orientation: " << this->pose.rot << " )" << std::endl;
 #endif
       if (!this->apply_in_gazebo_loop) {
         // this->model->SetLinkWorldPose(this->pose, this->link);
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
         this->model->SetWorldPose(this->pose);
 #else
         this->model->SetWorldPose(this->pose, this->link);
@@ -163,7 +159,7 @@ namespace gazebo
     {
       if (this->apply_in_gazebo_loop) {
         if (this->set_pose_flag) {
-#if __cplusplus >= 201103L
+#if GAZEBO_MAJOR_VERSION >= 7
           this->model->SetWorldPose(this->pose);
 #else
           this->model->SetWorldPose(this->pose, this->link);
@@ -189,9 +185,15 @@ namespace gazebo
     physics::ModelPtr model;
     std::string obj_name;
     std::string link_name;
+#if GAZEBO_MAJOR_VERSION >= 9
     ignition::math::Vector3d linear_vel;
     ignition::math::Vector3d angular_vel;
     ignition::math::Pose3d pose;
+#else
+    math::Vector3 linear_vel;
+    math::Vector3 angular_vel;
+    math::Pose pose;
+#endif
     physics::LinkPtr link;
     event::ConnectionPtr updateConnection;
     bool set_pose_flag;

--- a/hrpsys_gazebo_general/src/ThermoPlugin.cpp
+++ b/hrpsys_gazebo_general/src/ThermoPlugin.cpp
@@ -7,6 +7,10 @@
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Time.hh>
 
+#if GAZEBO_MAJOR_VERSION >= 7
+#include <ignition/math/Vector3.hh>
+#endif
+
 #include <ros/ros.h>
 #include <ros/callback_queue.h>
 #include <ros/advertise_options.h>
@@ -17,6 +21,18 @@
 #include <geometry_msgs/Vector3.h>
 
 #include "PubQueue.h"
+
+#if GAZEBO_MAJOR_VERSION >= 7
+#else
+namespace ignition::math
+{
+  using equal = gazebo::math::equal;
+  using clamp = gazebo::math::clamp;
+  using Pose3d = gazebo::math::Pose;
+  using Vector3d = gazebo::math::Vector3;
+  using Quaterniond = gazebo::math::Quaterion;
+}
+#endif
 
 namespace gazebo {
 class ThermoPlugin: public ModelPlugin {
@@ -59,7 +75,11 @@ public:
 		this->link = this->model->GetLink(this->link_name);
 		if (!this->link) { this->link = this->joint->GetChild(); }
 		this->world = this->model->GetWorld();
+#if GAZEBO_MAJOR_VERSION >= 7
+		this->lastUpdateTime = this->world->SimTime() ;
+#else
 		this->lastUpdateTime = this->world->GetSimTime() ;
+#endif		
 
 		// Make sure the ROS node for Gazebo has already been initialized
 		if (!ros::isInitialized()) {
@@ -102,15 +122,25 @@ public:
 	void OnUpdate(const common::UpdateInfo & /*_info*/) {
 		physics::JointPtr j = this->joint ;
 		physics::JointWrench w = j->GetForceTorque(0u);
-		math::Vector3 a = j->GetGlobalAxis(0u);
-		math::Vector3 m = this->link->GetWorldPose().rot * w.body2Torque;
+#if GAZEBO_MAJOR_VERSION >= 9
+		ignition::math::Vector3d a = j->GlobalAxis(0u);
+		ignition::math::Vector3d m = this->link->WorldPose().Rot() * w.body2Torque;
+#else
+		ignition::math::Vector3d a = j->GetGlobalAxis(0u);
+		ignition::math::Vector3d m = this->link->GetWorldPose().rot * w.body2Torque;	
+#endif
+
 		this->tau += (float)a.Dot(m);
 
 		if ( --this->thermal_calcuration_cnt > 0 ) return ;
 
 		this->tau /= this->thermal_calcuration_step;
 		this->thermal_calcuration_cnt = this->thermal_calcuration_step;
+#if GAZEBO_MAJOR_VERSION >= 7
+		common::Time curTime = this->world->SimTime();
+#else
 		common::Time curTime = this->world->GetSimTime();
+#endif
 		this->PublishThermo(curTime, this->lastUpdateTime);
 		this->lastUpdateTime = curTime ;
 		this->tau = 0;

--- a/hrpsys_gazebo_general/src/ThermoPlugin.cpp
+++ b/hrpsys_gazebo_general/src/ThermoPlugin.cpp
@@ -7,7 +7,7 @@
 #include <gazebo/common/common.hh>
 #include <gazebo/common/Time.hh>
 
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 #include <ignition/math/Vector3.hh>
 #endif
 
@@ -21,18 +21,6 @@
 #include <geometry_msgs/Vector3.h>
 
 #include "PubQueue.h"
-
-#if GAZEBO_MAJOR_VERSION >= 7
-#else
-namespace ignition::math
-{
-  using equal = gazebo::math::equal;
-  using clamp = gazebo::math::clamp;
-  using Pose3d = gazebo::math::Pose;
-  using Vector3d = gazebo::math::Vector3;
-  using Quaterniond = gazebo::math::Quaterion;
-}
-#endif
 
 namespace gazebo {
 class ThermoPlugin: public ModelPlugin {
@@ -75,7 +63,7 @@ public:
 		this->link = this->model->GetLink(this->link_name);
 		if (!this->link) { this->link = this->joint->GetChild(); }
 		this->world = this->model->GetWorld();
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 		this->lastUpdateTime = this->world->SimTime() ;
 #else
 		this->lastUpdateTime = this->world->GetSimTime() ;
@@ -126,17 +114,16 @@ public:
 		ignition::math::Vector3d a = j->GlobalAxis(0u);
 		ignition::math::Vector3d m = this->link->WorldPose().Rot() * w.body2Torque;
 #else
-		ignition::math::Vector3d a = j->GetGlobalAxis(0u);
-		ignition::math::Vector3d m = this->link->GetWorldPose().rot * w.body2Torque;	
+		math::Vector3 a = j->GetGlobalAxis(0u);
+		math::Vector3 m = this->link->GetWorldPose().rot * w.body2Torque;
 #endif
-
 		this->tau += (float)a.Dot(m);
 
 		if ( --this->thermal_calcuration_cnt > 0 ) return ;
 
 		this->tau /= this->thermal_calcuration_step;
 		this->thermal_calcuration_cnt = this->thermal_calcuration_step;
-#if GAZEBO_MAJOR_VERSION >= 7
+#if GAZEBO_MAJOR_VERSION >= 9
 		common::Time curTime = this->world->SimTime();
 #else
 		common::Time curTime = this->world->GetSimTime();


### PR DESCRIPTION
This PR includes https://github.com/start-jsk/rtmros_gazebo/pull/248.

`gazebo::math` is completely deprecated in `melodic`.

`hydro`, `indigo` and `kinetic` supports `gazebo::math`.
`kinetic` and `melodic` supports `ignition::math`
http://gazebosim.org/tutorials?tut=install_dependencies_from_source
http://gazebosim.org/tutorials/?tut=ros_wrapper_versions
https://bitbucket.org/osrf/gazebo/src/default/Migration.md?fileviewer=file-view-default

Since API of `ignition::math` is different from `gazebo::math`, we cannot use clever methods like https://github.com/start-jsk/rtmros_gazebo/commit/11de69ed03b702eec89f7698dbe8f111802225c6, so we have to write `"#ifdef #endif` everywhere `gazebo::math` is used.