### PR TITLE
Re-support indigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Please refer [rtmros_common] for installing these packages.
 Open Terminal and run gazebo
 
 ```
-roslaunch hrpsys_gazebo_general gazebo_samplerobot_no_controllers.launch
+roslaunch hrpsys_gazebo_general gazebo_samplerobot_no_controllers.launch  # kinetic and above
+roslaunch hrpsys_gazebo_general gazebo_samplerobot_no_controllers_indigo.launch  # indigo
 ```
 Launch another terminal and start hrpsys-base
 ```
-rtmlaunch hrpsys_gazebo_general samplerobot_hrpsys_bringup.launch
+rtmlaunch hrpsys_gazebo_general samplerobot_hrpsys_bringup.launch  # kinetic and above
+rtmlaunch hrpsys_gazebo_general samplerobot_hrpsys_bringup_indigo.launch  # indigo
 ```
 Launch another terminal and send command to robot by roseus
 ```
@@ -24,6 +26,8 @@ roseus samplerobot-interface.l
 (samplerobot-init)
 (setq *robot* (instance samplerobot-robot :init))
 (send *ri* :angle-vector (send *robot* :reset-pose) 5000)
+(send *ri* :start-auto-balancer)
+(send *ri* :start-st)
 (send *ri* :go-pos 0 0 0)
 ```
 

--- a/hrpsys_gazebo_general/config/SampleRobot_indigo.conf
+++ b/hrpsys_gazebo_general/config/SampleRobot_indigo.conf
@@ -1,0 +1,6 @@
+model: file://$(PROJECT_DIR)/..//model/sample1.wrl
+dt: 0.005
+
+abc_leg_offset: 0,0.09,0
+abc_stride_parameter: 0.15,0.05,10
+end_effectors: rarm,RARM_WRIST_P,CHEST,0.0,-5.684342e-17,-0.12,9.813078e-18,1.0,0.0,1.5708, larm,LARM_WRIST_P,CHEST,0.0,5.684342e-17,-0.12,-9.813078e-18,1.0,0.0,1.5708, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0,

--- a/hrpsys_gazebo_general/config/SampleRobot_indigo.yaml
+++ b/hrpsys_gazebo_general/config/SampleRobot_indigo.yaml
@@ -1,0 +1,122 @@
+hrpsys_gazebo_configuration:
+## velocity feedback for joint control, use parameter gains/joint_name/p_v
+  use_velocity_feedback: true
+## synchronized hrpsys and gazebo
+# use_synchronized_command: false
+# name of robot (using for namespace)
+  robotname: SampleRobot
+# joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28]
+# joints list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
+  joints:
+    - RLEG_HIP_R
+    - RLEG_HIP_P
+    - RLEG_HIP_Y
+    - RLEG_KNEE
+    - RLEG_ANKLE_P
+    - RLEG_ANKLE_R
+    - RARM_SHOULDER_P
+    - RARM_SHOULDER_R
+    - RARM_SHOULDER_Y
+    - RARM_ELBOW
+    - RARM_WRIST_Y
+    - RARM_WRIST_P
+    - RARM_WRIST_R
+    - LLEG_HIP_R
+    - LLEG_HIP_P
+    - LLEG_HIP_Y
+    - LLEG_KNEE
+    - LLEG_ANKLE_P
+    - LLEG_ANKLE_R
+    - LARM_SHOULDER_P
+    - LARM_SHOULDER_R
+    - LARM_SHOULDER_Y
+    - LARM_ELBOW
+    - LARM_WRIST_Y
+    - LARM_WRIST_P
+    - LARM_WRIST_R
+    - WAIST_P
+    - WAIST_R
+    - CHEST
+## comment for joint index
+# 0   - RLEG_HIP_R
+# 1   - RLEG_HIP_P
+# 2   - RLEG_HIP_Y
+# 3   - RLEG_KNEE
+# 4   - RLEG_ANKLE_P
+# 5   - RLEG_ANKLE_R
+# 6   - RARM_SHOULDER_P
+# 7   - RARM_SHOULDER_R
+# 8   - RARM_SHOULDER_Y
+# 9   - RARM_ELBOW
+# 10  - RARM_WRIST_Y
+# 11  - RARM_WRIST_P
+# 12  - RARM_WRIST_R
+# 13  - LLEG_HIP_R
+# 14  - LLEG_HIP_P
+# 15  - LLEG_HIP_Y
+# 16  - LLEG_KNEE
+# 17  - LLEG_ANKLE_P
+# 18  - LLEG_ANKLE_R
+# 19  - LARM_SHOULDER_P
+# 20  - LARM_SHOULDER_R
+# 21  - LARM_SHOULDER_Y
+# 22  - LARM_ELBOW
+# 23  - LARM_WRIST_Y
+# 24  - LARM_WRIST_P
+# 25  - LARM_WRIST_R
+# 26  - WAIST_P
+# 27  - WAIST_R
+# 28  - CHEST
+## joint gain settings
+  gains:
+    LLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_P:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_R:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    CHEST:           {p: 6000.0, d:   2.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    LARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    RARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+## force sensor settings
+## list of force sensorname
+  force_torque_sensors:
+    - lfsensor
+    - rfsensor
+    - lhsensor
+    - rhsensor
+## configuration of force sensor
+## key of force_torque_sensors_config should be a member of force_torque_sensors
+  force_torque_sensors_config:
+    lfsensor: {joint_name: 'LLEG_ANKLE_R', frame_id: 'LLEG_LINK6', translation: [0, 0, 0], rotation: [1, 0, 0, 0]}
+    rfsensor: {joint_name: 'RLEG_ANKLE_R', frame_id: 'RLEG_LINK6', translation: [0, 0, 0], rotation: [1, 0, 0, 0]}
+    lhsensor: {joint_name: 'LARM_WRIST_R', frame_id: 'LARM_LINK7'}
+    rhsensor: {joint_name: 'RARM_WRIST_R', frame_id: 'RARM_LINK7'}
+## IMU sensor settings
+## configuration of IMU sensor
+## key of imu_sensors_config should be a member of imu_sensors
+  imu_sensors:
+    - imu_sensor0
+  imu_sensors_config:
+    imu_sensor0: {ros_name: 'sample_imu_sensor', link_name: 'WAIST_LINK0', frame_id: 'WAIST_LINK0'}

--- a/hrpsys_gazebo_general/launch/gazebo_samplerobot_no_controllers_indigo.launch
+++ b/hrpsys_gazebo_general/launch/gazebo_samplerobot_no_controllers_indigo.launch
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="gzname" default="gazebo"/>
+  <arg name="WORLD" default="$(find hrpsys_gazebo_general)/worlds/empty.world"/>
+  <arg name="PAUSED" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
+    <arg name="ROBOT_TYPE" value="SampleRobot" />
+    <arg name="WORLD" value="$(arg WORLD)" />
+    <arg name="HRPSYS_GAZEBO_CONFIG" default="$(find hrpsys_gazebo_general)/config/SampleRobot_indigo.yaml" />
+    <arg name="ROBOT_MODEL" default="$(find hrpsys_gazebo_general)/robot_models/SampleRobot/SampleRobot.urdf.xacro" />
+
+    <arg name="PAUSED" value="$(arg PAUSED)"/>
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="gzname" value="$(arg gzname)" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup_indigo.launch
+++ b/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup_indigo.launch
@@ -1,0 +1,29 @@
+<launch>
+  <arg name="KINEMATICS_MODE" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <rosparam command="load"
+            file="$(find hrpsys_ros_bridge)/models/SampleRobot_controller_config.yaml" />
+
+  <!-- TODO: fix colladaWriter see https://code.google.com/p/rtm-ros-robotics/issues/detail?id=182 -->
+  <node pkg="tf" type="static_transform_publisher" name="sensor_transform_0"
+        args="0 0 0 0 0 0 /LLEG_LINK6 /LLEG_ANKLE_R 100" />
+  <node pkg="tf" type="static_transform_publisher" name="sensor_transform_1"
+        args="0 0 0 0 0 0 /RLEG_LINK6 /RLEG_ANKLE_R 100" />
+  <node pkg="tf" type="static_transform_publisher" name="sensor_transform_2"
+        args="0 0 0 0 0 0 /LARM_LINK7 /LARM_WRIST_P 100" />
+  <node pkg="tf" type="static_transform_publisher" name="sensor_transform_3"
+        args="0 0 0 0 0 0 /RARM_LINK7 /RARM_WRIST_P 100" />
+  <node pkg="tf" type="static_transform_publisher" name="sensor_transform_4"
+        args="0 0 0 0 0 0 /WAIST_LINK0 gyrometer 100" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/robot_hrpsys_bringup.launch">
+    <arg name="ROBOT_TYPE" value="SampleRobot" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="HRPSYS_PY_ARGS" value="--use-unstable-rtc" />
+    <arg name="CONF_FILE" default="$(find hrpsys_gazebo_general)/config/SampleRobot_indigo.conf" />
+    <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
+    <arg name="BASE_LINK" value="WAIST_LINK0" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup_indigo.launch
+++ b/hrpsys_gazebo_general/launch/samplerobot_hrpsys_bringup_indigo.launch
@@ -25,5 +25,6 @@
     <arg name="CONF_FILE" default="$(find hrpsys_gazebo_general)/config/SampleRobot_indigo.conf" />
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
     <arg name="BASE_LINK" value="WAIST_LINK0" />
+    <arg name="HRPSYS_RATE"  value="200" />
   </include>
 </launch>


### PR DESCRIPTION
#250 drops indigo support.
This PR re-supports indigo by adding old config and launch files.
(Only one fix is that [specify 200Hz explicitly](https://github.com/start-jsk/rtmros_gazebo/pull/253/files#diff-e1f3c1465aa2b4218d748a49e0b34646R28) because indigo config is for 200Hz)
Also, I added indigo information to README.

### Minor fix
I think `(send *ri* :start-auto-balancer)` and `(send *ri* :start-st)` are skipped in roseus commands on README, so I added them.
@Naoki-Hiraoka Is this correct?